### PR TITLE
bean: improved remove-blur patch & rename debug-menu patch

### DIFF
--- a/patches/584108A9.patch
+++ b/patches/584108A9.patch
@@ -20,7 +20,7 @@ title_id = "584108A9"
 [[patch]]
     name = "Remove Blur in Classic Graphics"
     desc = "Can still be enabled as 'Vaseline-o-vision' cheat"
-    author = "emoose"
+    author = "illusion, emoose"
     is_enabled = false
 
     [[patch.be32]]
@@ -29,7 +29,7 @@ title_id = "584108A9"
 
 [[patch]]
     name = "Debug Menu"
-    desc = "Press LB"
+    desc = "Press LB to open menu"
     author = "N/A"
     is_enabled = false
 

--- a/patches/584108A9.patch
+++ b/patches/584108A9.patch
@@ -18,20 +18,17 @@ title_id = "584108A9"
         value = 0x01
 
 [[patch]]
-    name = "Remove Blur in Classic Graphics (Partially)"
-    desc = ""
-    author = "illusion"
+    name = "Remove Blur in Classic Graphics"
+    desc = "Can still be enabled as 'Vaseline-o-vision' cheat"
+    author = "emoose"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x821891b0
-        value = 0x60000000
-    [[patch.be32]]
-        address = 0x82189270
+        address = 0x82188E70
         value = 0x60000000
 
 [[patch]]
-    name = "Pause Menu"
+    name = "Debug Menu"
     desc = "Press LB"
     author = "N/A"
     is_enabled = false


### PR DESCRIPTION
Current patch makes the classic graphics have a noisy effect on them, this patch works differently and seems to remove the blur without any bad effects.

(the check near where I patch is also checking for the 0x4E cheat-ID for "vaseline-o-vision", seems 82136FA0 is some sort of "isCheatActive" function - that check is left intact so the cheat/debug option should still work)