### PR TITLE
Update 5454082B - Red Dead Redemption (Launch NTSC Disc).patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ title_id = "545407DF"
 
 Plugins for loading Xbox 360 executables. Only useful for developers.
 
-Breakpoints can be set in CE or MSVC with `emit_source_annotations`
+Memory Breakpoints can be set in CE or MSVC with `emit_source_annotations`
+
+This will show xex address when breakpoint is hit, although there is currently no way to set breakpoint on execution within the Xenia Debugger.
+
+Xex loader plugins for Reverse Engineering tools:
 
 [IDA 6 XEX Loader](http://xorloser.com/blog/?p=395)
 
@@ -47,11 +51,7 @@ Breakpoints can be set in CE or MSVC with `emit_source_annotations`
 
 2. Extract the patches folder to where your Xenia Canary executable is located.
 
-<details><summary>Image (Click to Expand)</summary>
-
 ![](https://cdn.discordapp.com/attachments/747164286056661153/764464248176115712/unknown.png)
-
-</details>
 
 3. To enable patches (if they're not already enabled by default), open the .patch file that corresponds to your game's ID with a text editor (Notepad, Notepad++, VSCode, etc.), and set `is_enabled` from `false` to `true`
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ title_id = "545407DF"
 
 ### For Developers
 
-Plugins for loading Xbox 360 executables. Only useful for developers.
-
 Memory Breakpoints can be set in CE or MSVC with `emit_source_annotations`
 
 This will show xex address when breakpoint is hit, although there is currently no way to set breakpoint on execution within the Xenia Debugger.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains Game Patches available for the Xenia Emulator.
 
  - If the game you are submitting a patch for already has a .patch file, then create a Pull Request to edit that file and add your name in author.
 
- - This new file must be named `[Title ID].patch` - For example, a patch file for Halo 3 must be called `4D5307E6.patch` (All uppercase)
+ - This new file must be named `[Title ID] - Game Title.patch` - For example, a patch file for Halo 3 must be called `4D5307E6 - Halo 3.patch`
 
  - File must contain empty line at end of file.
 

--- a/patches/5454082B - Red Dead Redemption (Launch NTSC Disc).patch
+++ b/patches/5454082B - Red Dead Redemption (Launch NTSC Disc).patch
@@ -1,6 +1,7 @@
 title_name = "Red Dead Redemption"
 title_id = "5454082B"
-hash = "82CDA3C91B57C170"
+#hash = "82CDA3C91B57C170"
+#hash = "BCEC4C4143B6BF5F"
 #media_id = "2AAB34E2"
 
 [[patch]]


### PR DESCRIPTION
Hash does not match up with games that have had Title Updates patched.
Commented out hash and added personal hash from my version which has been patched.

Everybody should patch their base version of non-GOTY, as the released retail version had many, many, many scripting bugs that were fixed with subsequent updates.

Can multiple hashes from a selection be allowed?