### PR TITLE
Added mach speed Washing Machine fix

### DIFF
--- a/patches/58410955 - Banjo Tooie.patch
+++ b/patches/58410955 - Banjo Tooie.patch
@@ -131,6 +131,9 @@ title_id = "58410955"
     [[patch.be16]]
         address = 0x8213E362
         value = 0x0B0C
+    [[patch.be16]]
+        address = 0x821129BA
+        value = 0x1EF8
 
 [[patch]]
     name = "HD Shadows"


### PR DESCRIPTION
Sorry,I had completely forgotten about finding and adding the washing machine mach speed fix.
The fix prevents washing machine Banjo from going mach speed when attacking while moving on 60fps.