### PR TITLE
5454082B - New Patches and Cleanup

### DIFF
--- a/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch
+++ b/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch
@@ -3,39 +3,17 @@ title_id = "5454082B"
 hash = "F8F5F22E950BE693"
 
 [[patch]]
-    name = "Infinite Ammo"
-    desc = "100 in reserved magazine."
-    author = "illusion, boma"
+    name = "Unlock FPS"
+    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    author = "boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825B9DD4
-        value = 0x3C0042C8 # Ammo amount in 2 bytes float. Default is 100. It will reset to 100 after some idle time.
-    [[patch.be32]]
-        address = 0x825B9DD8
-        value = 0x900A0000
-
-[[patch]]
-    name = "Infinite Horse Stamina"
-    author = "illusion, boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82C77738
-        value = 0x3C003F80
-    [[patch.be32]]
-        address = 0x82C7773C
-        value = 0x9007000C
-
-[[patch]]
-    name = "Skip Grass Occlusion"
-    desc = "Gets rid of grass."
-    author = "illusion, boma"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x822EE494
-        value = 0x4800
+        address = 0x823C674C
+        value = 0x48000048
+    [[patch.be8]]
+        address = 0x82C4E607
+        value = 0x01
 
 [[patch]]
     name = "Disable Depth of Field + Motion Blur"
@@ -54,3 +32,128 @@ hash = "F8F5F22E950BE693"
     [[patch.be32]]
         address = 0x822B5E10
         value = 0x38A00010
+
+[[patch]]
+    name = "Skip Grass Occlusion"
+    desc = "Gets rid of grass."
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x822EE494
+        value = 0x4800
+
+[[patch]]
+    name = "No Trees"
+    desc = "Provides a substantial performance boost."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8276CEC8
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable Shadows"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82927B40
+        value = 0x60000000
+
+[[patch]]
+    name = "480p Mode"
+    desc = "Internally renders the game at 480p and upscales to 720p. Certain objects and terrain will exhibit irregular pop-in."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82770D08
+        value = 0x39400001
+
+[[patch]]
+    name = "Higher Quality Post Processing"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827D809C
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable SSAO"
+    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822FCB40
+        value = 0x48000114
+
+[[patch]]
+    name = "Skip Intro Rockstar Movie"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8278F56C
+        value = 0x41
+
+[[patch]]
+    name = "Alternative Script Timing & Asset Garbage Collection"
+    desc = "May provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82300AD0
+        value = 0x39600001
+    [[patch.be32]]
+        address = 0x8242011C
+        value = 0x39600001
+
+[[patch]]
+    name = "Use Separate Audio Heap"
+    desc = "Changes audio component heap memory. Will lower the quality of realtime audio post-processing but may provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823DF33C
+        value = 0x39600001
+
+[[patch]]
+    name = "Aspect Ratio"
+    desc = "See note about aspect ratio patches in README."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82000D7C
+        value = 0x4018E38E
+
+[[patch]]
+    name = "Infinite Horse Stamina"
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82C77738
+        value = 0x3C003F80
+    [[patch.be32]]
+        address = 0x82C7773C
+        value = 0x9007000C
+
+[[patch]]
+    name = "Infinite Ammo"
+    desc = "100 in reserved magazine."
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825B9DD4
+        value = 0x3C0042C8 # Ammo amount in 2 bytes float. Default is 100. It will reset to 100 after some idle time.
+    [[patch.be32]]
+        address = 0x825B9DD8
+        value = 0x900A0000

--- a/patches/5454082B - Red Dead Redemption (GOTY, Disc 2).patch
+++ b/patches/5454082B - Red Dead Redemption (GOTY, Disc 2).patch
@@ -3,42 +3,20 @@ title_id = "5454082B"
 hash = "C267D3CAF98E4368"
 
 [[patch]]
-    name = "Infinite Ammo"
-    desc = "100 in reserved magazine."
-    author = "illusion, boma"
+    name = "Unlock FPS"
+    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    author = "boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825BA13C
-        value = 0x3C0042C8 # Ammo amount in 2 bytes float. Default is 100. It will reset to 100 after some idle time.
-    [[patch.be32]]
-        address = 0x825BA140
-        value = 0x900A0000
+        address = 0x823C655C
+        value = 0x48000048
+    [[patch.be8]]
+        address = 0x82C4CF0F
+        value = 0x01
 
 [[patch]]
-    name = "Infinite Horse Stamina"
-    author = "illusion, boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82C76038
-        value = 0x3C003F80
-    [[patch.be32]]
-        address = 0x82C7603C
-        value = 0x9007000C
-
-[[patch]]
-    name = "Skip Grass Occlusion"
-    desc = "Gets rid of grass."
-    author = "illusion, boma"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x822EE5E4
-        value = 0x4800
-
-[[patch]]
-    name = "Disable Depth of Field + Motion Blur"
+    name = "Disable Depth of Field & Motion Blur"
     author = "illusion, boma"
     is_enabled = false
 
@@ -54,3 +32,128 @@ hash = "C267D3CAF98E4368"
     [[patch.be32]]
         address = 0x822B5EE0
         value = 0x38A00010
+
+[[patch]]
+    name = "Skip Grass Occlusion"
+    desc = "Gets rid of grass."
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x822EE5E4
+        value = 0x4800
+
+[[patch]]
+    name = "No Trees"
+    desc = "Provides a substantial performance boost."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8276C3F0
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable Shadows"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82927830
+        value = 0x60000000
+
+[[patch]]
+    name = "480p Mode"
+    desc = "Internally renders the game at 480p and upscales to 720p. Certain objects and terrain will exhibit irregular pop-in."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827702A8
+        value = 0x39400001
+
+[[patch]]
+    name = "Higher Quality Post Processing"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827D78CC
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable SSAO"
+    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822FCC40
+        value = 0x48000114
+
+[[patch]]
+    name = "Skip Intro Rockstar Movie"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8278EDE4
+        value = 0x41
+
+[[patch]]
+    name = "Alternative Script Timing & Asset Garbage Collection"
+    desc = "May provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82300BD0
+        value = 0x39600001
+    [[patch.be32]]
+        address = 0x824200FC
+        value = 0x39600001
+
+[[patch]]
+    name = "Use Separate Audio Heap"
+    desc = "Changes audio component heap memory. Will lower the quality of realtime audio post-processing but may provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823DF164
+        value = 0x39600001
+
+[[patch]]
+    name = "Aspect Ratio"
+    desc = "See note about aspect ratio patches in README."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82000D80
+        value = 0x4018E38E
+
+[[patch]]
+    name = "Infinite Horse Stamina"
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82C76038
+        value = 0x3C003F80
+    [[patch.be32]]
+        address = 0x82C7603C
+        value = 0x9007000C
+
+[[patch]]
+    name = "Infinite Ammo"
+    desc = "100 in reserved magazine."
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825BA13C
+        value = 0x3C0042C8 # Ammo amount in 2 bytes float. Default is 100. It will reset to 100 after some idle time.
+    [[patch.be32]]
+        address = 0x825BA140
+        value = 0x900A0000

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC).patch
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC).patch
@@ -85,7 +85,7 @@ hash = "82CDA3C91B57C170"
     name = "Disable SSAO"
     desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
     author = "boma"
-    is_enabled = true
+    is_enabled = false
 
     [[patch.be32]]
         address = 0x822FAFE8

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC).patch
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC).patch
@@ -69,7 +69,7 @@ hash = "82CDA3C91B57C170"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82754B10  # change to 0x82754BC4 for alternative 480p mode without asset pop-in but less performance gains 
+        address = 0x82754B10  # change to 0x82754BC4 for alternative 480p mode without asset pop-in but less performance gains
         value = 0x39400001 # change to 0x39600001 for alternative 480p mode
 
 [[patch]]

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC).patch
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC).patch
@@ -3,6 +3,159 @@ title_id = "5454082B"
 hash = "82CDA3C91B57C170"
 
 [[patch]]
+    name = "Unlock FPS"
+    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823C53F4
+        value = 0x48000048
+    [[patch.be8]]
+        address = 0x82C23347
+        value = 0x01
+
+[[patch]]
+    name = "Disable Depth of Field & Motion Blur"
+    author = "illusion"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x827C697C
+        value = 0x4800
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822B4B30
+        value = 0x38A00010
+
+[[patch]]
+    name = "Skip Grass Occlusion"
+    desc = "Gets rid of grass."
+    author = "illusion"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x822ECC9C
+        value = 0x4800
+
+[[patch]]
+    name = "No Trees"
+    desc = "Provides a substantial performance boost."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82750D18
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable Shadows"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82902070
+        value = 0x60000000
+
+[[patch]]
+    name = "480p Mode"
+    desc = "Internally renders the game at 480p and upscales to 720p. Certain objects and terrain will exhibit irregular pop-in."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82754B10  # change to 0x82754BC4 for alternative 480p mode without asset pop-in but less performance gains 
+        value = 0x39400001 # change to 0x39600001 for alternative 480p mode
+
+[[patch]]
+    name = "Higher Quality Post Processing"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827B63FC
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable SSAO"
+    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
+    author = "boma"
+    is_enabled = true
+
+    [[patch.be32]]
+        address = 0x822FAFE8
+        value = 0x48000114
+
+[[patch]]
+    name = "Skip Intro Rockstar Movie"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82770814
+        value = 0x41
+
+[[patch]]
+    name = "Alternative Script Timing & Asset Garbage Collection"
+    desc = "May provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822FEF88
+        value = 0x39600001
+    [[patch.be32]]
+        address = 0x8241A53C
+        value = 0x39600001
+
+[[patch]]
+    name = "Use Separate Audio Heap"
+    desc = "Changes audio component heap memory. Will lower the quality of realtime audio post-processing but may provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823DF854
+        value = 0x39600001
+
+[[patch]]
+    name = "Aspect Ratio"
+    desc = "See note about aspect ratio patches in README."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82000D70
+        value = 0x4018E38E
+
+[[patch]]
+    name = "Use Cheats Without Losing Autosave"
+    desc = "Autosave will be disabled for the rest of your play session after activating a cheat but will function normally upon reopening the game."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82419ED8
+        value = 0x60000000
+
+[[patch]]
+    name = "Infinite Horse Stamina"
+    author = "illusion"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82C4C430
+        value = 0x3C003F80
+    [[patch.be32]]
+        address = 0x82C4C434
+        value = 0x9007000C
+
+[[patch]]
     name = "Bottomless Clip"
     author = "illusion"
     is_enabled = false
@@ -26,34 +179,3 @@ hash = "82CDA3C91B57C170"
     [[patch.be32]]
         address = 0x825AB380
         value = 0x900A0000
-
-[[patch]]
-    name = "Infinite Horse Stamina"
-    author = "illusion"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82C4C430
-        value = 0x3C003F80
-    [[patch.be32]]
-        address = 0x82C4C434
-        value = 0x9007000C
-
-[[patch]]
-    name = "Skip Grass Occlusion"
-    desc = "Gets rid of grass."
-    author = "illusion"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x822ECC9C
-        value = 0x4800
-
-[[patch]]
-    name = "Disable Depth of Field + Motion Blur"
-    author = "illusion"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x827C697C
-        value = 0x4800

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC, TU9).patch
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC, TU9).patch
@@ -3,17 +3,135 @@ title_id = "5454082B"
 hash = "BCEC4C4143B6BF5F"
 
 [[patch]]
-    name = "Infinite Ammo"
-    desc = "100 in reserved magazine."
-    author = "illusion, boma"
+    name = "Unlock FPS"
+    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    author = "boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825B7334
-        value = 0x3C0042C8 # Ammo amount in 2 bytes float. Default is 100. It will reset to 100 after some idle time.
+        address = 0x823C5784
+        value = 0x48000048
+    [[patch.be8]]
+        address = 0x82C1F5BF
+        value = 0x01
+
+[[patch]]
+    name = "Disable Depth of Field & Motion Blur"
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x827BA164
+        value = 0x4800
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "boma"
+    is_enabled = false
+
     [[patch.be32]]
-        address = 0x825B7338
-        value = 0x900A0000
+        address = 0x822B55F8
+        value = 0x38A00010
+
+[[patch]]
+    name = "No Trees"
+    desc = "Provides a substantial performance boost."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8273E758
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable Shadows"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x828F9220
+        value = 0x60000000
+
+[[patch]]
+    name = "480p Mode"
+    desc = "Internally renders the game at 480p and upscales to 720p. Certain objects and terrain will exhibit irregular pop-in."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827425C8  # change to 0x8274267C for alternative 480p mode without asset pop-in but less performance gains
+        value = 0x39400001 # change to 0x39600001 for alternative 480p mode
+
+[[patch]]
+    name = "Higher Quality Post Processing"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827A93BC
+        value = 0x39600001
+
+[[patch]]
+    name = "Disable SSAO"
+    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822FC4A8
+        value = 0x48000114
+
+[[patch]]
+    name = "Skip Intro Rockstar Movie"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82760ADC
+        value = 0x41
+
+[[patch]]
+    name = "Alternative Script Timing & Asset Garbage Collection"
+    desc = "May provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82300438
+        value = 0x39600001
+    [[patch.be32]]
+        address = 0x8241F0E0
+        value = 0x39600001
+
+[[patch]]
+    name = "Use Separate Audio Heap"
+    desc = "Changes audio component heap memory. Will lower the quality of realtime audio post-processing but may provide a small performance boost for CPU-limited systems."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823DE36C
+        value = 0x39600001
+
+[[patch]]
+    name = "Aspect Ratio"
+    desc = "See note about aspect ratio patches in README."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82000D90
+        value = 0x4018E38E
+
+[[patch]]
+    name = "Skip Grass Occlusion"
+    desc = "Gets rid of grass."
+    author = "illusion, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x822EDE84
+        value = 0x4800
 
 [[patch]]
     name = "Infinite Horse Stamina"
@@ -28,20 +146,14 @@ hash = "BCEC4C4143B6BF5F"
         value = 0x9007000C
 
 [[patch]]
-    name = "Skip Grass Occlusion"
-    desc = "Gets rid of grass."
+    name = "Infinite Ammo"
+    desc = "100 in reserved magazine."
     author = "illusion, boma"
     is_enabled = false
 
-    [[patch.be16]]
-        address = 0x822EDE84
-        value = 0x4800
-
-[[patch]]
-    name = "Disable Depth of Field + Motion Blur"
-    author = "illusion, boma"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x827BA164
-        value = 0x4800
+    [[patch.be32]]
+        address = 0x825B7334
+        value = 0x3C0042C8 # Ammo amount in 2 bytes float. Default is 100. It will reset to 100 after some idle time.
+    [[patch.be32]]
+        address = 0x825B7338
+        value = 0x900A0000


### PR DESCRIPTION
WIP. Need to find the offsets for GOTY and make sure they all work.

Sun flare occlusion patch is currently incomplete and isn't being published. Although the rays no longer cast, the flare sprite is still being drawn.

Since I have only been able to test the relative performance differences using my mobile Zen2, and since RDR is particularly CPU limited, I'd appreciate it if others could test the patches on their Intel CPUs and report back.