### PR TITLE
RDR: disable sun/lens flare

### DIFF
--- a/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch.toml
@@ -4,6 +4,19 @@ title_id = "5454082B" # TT-2091
 #media_id = "3EE87B76" http://redump.org/disc/58711
 
 [[patch]]
+    name = "Skip Intro"
+    desc = "Skips legal and intro videos."
+    author = "illusion"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8278F6B0
+        value = 0x480001A0 # b 0x8278F850
+    [[patch.be32]]
+        address = 0x8278F850
+        value = 0x3B600001 # li r27,0x1
+
+[[patch]]
     name = "Unlock FPS"
     desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
     author = "boma"

--- a/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch.toml
@@ -190,3 +190,13 @@ title_id = "5454082B" # TT-2091
     [[patch.be32]]
         address = 0x825B9DD8
         value = 0x900A0000
+
+[[patch]]
+    name = "Disable Sun Flare"
+    desc = "Sun flare effect can clip through buildings when playing with increased resolutions, this prevents the effect from rendering"
+    author = "emoose"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x827833B4
+        value = 0x4800


### PR DESCRIPTION
Seems the sun flare effect can clip through buildings when playing with increased resolutions, this prevents the effect from rendering.

Played for a few hours with this and didn't see any noticeable artifacts, the code patched here should only be sunflare related hopefully. 

I only have the Disc 1 GOTY edition ripped right now, if anyone is able to port this to the other versions it'd be appreciated, otherwise I'll try seeing if I can get hold of Disc 2 to port it there soon.

E: ugh github editor added a bunch of indents that broke linter, force pushed a fix.