### PR TITLE
Remove obsolete hashes

### DIFF
--- a/patches/415607DD - Tony Hawk's Project 8.patch.toml
+++ b/patches/415607DD - Tony Hawk's Project 8.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Tony Hawk's Project 8"
 title_id = "415607DD" # AV-2013
-hash = "71EC21E5740F451F" # default.xex
+#hash = "" # default.xex
 #media_id = "2CB96AE4" http://redump.org/disc/57372
 
 [[patch]]

--- a/patches/415607F5 - Bee Movie Game.patch.toml
+++ b/patches/415607F5 - Bee Movie Game.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Bee Movie Game"
 title_id = "415607F5" # AV-2037
-hash = "AD1BCBC59AD931E1" # Default.xex
+#hash = "" # default.xex
 #media_id = "393A39F1" http://redump.org/disc/55424
 
 [[patch]]

--- a/patches/415608C5 - Family Guy Back to the Multiverse.patch.toml
+++ b/patches/415608C5 - Family Guy Back to the Multiverse.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Family Guy: Back to the Multiverse" # BTTM
 title_id = "415608C5" # AV-2245
-hash = "4ECA49804126DF60" # DEFAULT.XEX
+#hash = "" # default.xex
 #media_id = "55DA4FA1" http://redump.org/disc/55407
 
 [[patch]]

--- a/patches/425307D1 - The Elder Scrolls IV Oblivion (GOTY).patch.toml
+++ b/patches/425307D1 - The Elder Scrolls IV Oblivion (GOTY).patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Elder Scrolls IV: Oblivion (GOTY)" # Game Of The Year, 4
 title_id = "425307D1" # BS-2001
-hash = "58C7E2BE53BBE0C2" # default.xex
+#hash = "" # default.xex
 #media_id = "013FE217"
 
 [[patch]]

--- a/patches/425307E6 - The Elder Scrolls V Skyrim.patch.toml
+++ b/patches/425307E6 - The Elder Scrolls V Skyrim.patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Elder Scrolls V: Skyrim" # 5
 title_id = "425307E6" # BS-2022
-hash = "48EB3885CE2F2295" # default.xex
+#hash = "" # default.xex
 #media_id = "34F5B6C3" http://redump.org/disc/37091
 
 [[patch]]

--- a/patches/43430817 - Asura's Wrath.patch.toml
+++ b/patches/43430817 - Asura's Wrath.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Asura's Wrath"
 title_id = "43430817" # CC-2071
-hash = "DC174EBFEF0DE09E" # default.xex
+#hash = "" # default.xex
 #media_id = "11DFADD6" http://redump.org/disc/38905
 
 [[patch]]

--- a/patches/434D0822 - Leisure Suit Larry Box Office Bust.patch.toml
+++ b/patches/434D0822 - Leisure Suit Larry Box Office Bust.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Leisure Suit Larry: Box Office Bust"
 title_id = "434D0822" # CM-2082
-hash = "654C4EEDC39B5972" # default.xex
+#hash = "" # default.xex
 #media_id = "536000E3" http://redump.org/disc/14255
 
 [[patch]]

--- a/patches/45410809 - The Simpsons Game.patch.toml
+++ b/patches/45410809 - The Simpsons Game.patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Simpsons Game"
 title_id = "45410809" # EA-2057
-hash = "5BD3AD729965268F" # default.xex
+#hash = "" # default.xex
 #media_id = "05631042" http://redump.org/disc/12510
 
 [[patch]]

--- a/patches/4541080F - The Orange Box (engine_360.dll).patch.toml
+++ b/patches/4541080F - The Orange Box (engine_360.dll).patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Orange Box"
 title_id = "4541080F" # EA-2063
-hash = "0781DC9FEF7F4812" # engine_360.dll
+#hash = "" # engine_360.dll
 #media_id = "651A85DA" http://redump.org/disc/11838
 
 [[patch]]

--- a/patches/4541080F - The Orange Box (shaderapidx9_360.dll).patch.toml
+++ b/patches/4541080F - The Orange Box (shaderapidx9_360.dll).patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Orange Box"
 title_id = "4541080F" # EA-2063
-hash = "2F625731A758A357" # shaderapidx9_360.dll
+#hash = "" # shaderapidx9_360.dll
 #media_id = "651A85DA" http://redump.org/disc/11838
 
 [[patch]]

--- a/patches/4541080F - The Orange Box (tf-bin-Client_360.dll).patch.toml
+++ b/patches/4541080F - The Orange Box (tf-bin-Client_360.dll).patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Orange Box" # Team Fortress 2
 title_id = "4541080F" # EA-2063
-hash = "946F93B576F9CF9D" # tf/bin/Client_360.dll
+#hash = "" # tf/bin/Client_360.dll
 #media_id = "651A85DA" http://redump.org/disc/11838
 
 [[patch]]

--- a/patches/454108E6 - Skate 3.patch.toml
+++ b/patches/454108E6 - Skate 3.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Skate 3"
 title_id = "454108E6" # EA-2278
-hash = "237E390A819E75D8" # default.xex
+#hash = "" # default.xex
 #media_id = "5C087C2C" http://redump.org/disc/13321
 
 [[patch]]

--- a/patches/4541092A - Shadows of the Damned.patch.toml
+++ b/patches/4541092A - Shadows of the Damned.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Shadows of the Damned"
 title_id = "4541092A" # EA-2346
-hash = "BAC5CBBDF9D3E8AF" # default.xex
+#hash = "" # default.xex
 #media_id = "64D9671A" http://redump.org/disc/58068
 
 [[patch]]

--- a/patches/4541096D - SSX.patch.toml
+++ b/patches/4541096D - SSX.patch.toml
@@ -1,6 +1,6 @@
 title_name = "SSX™"
 title_id = "4541096D" # EA-2413
-hash = "DB8EF60BBEBA0BBD" # default.xex
+#hash = "" # default.xex
 #media_id = "55ABAB6C" http://redump.org/disc/38999
 
 [[patch]]

--- a/patches/475007D2 - Hail to the Chimp.patch.toml
+++ b/patches/475007D2 - Hail to the Chimp.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Hail to the Chimp"
 title_id = "475007D2" # GP-2002
-hash = "E12DC80C1122B0EB" # default.xex
+#hash = "" # default.xex
 #media_id = "773093A4"
 
 [[patch]]

--- a/patches/494F07D1 - El Shaddai.patch.toml
+++ b/patches/494F07D1 - El Shaddai.patch.toml
@@ -1,6 +1,6 @@
 title_name = "El Shaddai"
 title_id = "494F07D1" # IO-2001
-hash = "34A73675FE9488AB" # DEFAULT.XEX
+#hash = "" # default.xex
 #media_id = "640B378B" http://redump.org/disc/42246
 
 [[patch]]

--- a/patches/4B4E0823 - Silent Hill Downpour.patch.toml
+++ b/patches/4B4E0823 - Silent Hill Downpour.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Silent Hill: Downpour"
 title_id = "4B4E0823" # KN-2083
-hash = "BF984B0B103241BA" # default.xex
+#hash = "" # default.xex
 #media_id = "7D387D17" http://redump.org/disc/58138
 
 [[patch]]

--- a/patches/4B5607E8 - Dead or Alive 5 Ultimate.patch.toml
+++ b/patches/4B5607E8 - Dead or Alive 5 Ultimate.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Dead or Alive 5 Ultimate" # DOA
 title_id = "4B5607E8" # KV-2024
-hash = "776925843D52BD83" # default.xex
+#hash = "" # default.xex
 #media_id = "4C6BA48E" http://redump.org/disc/72662
 
 [[patch]]

--- a/patches/4C4107D7 - LEGO Star Wars The Complete Saga.patch.toml
+++ b/patches/4C4107D7 - LEGO Star Wars The Complete Saga.patch.toml
@@ -1,6 +1,6 @@
 title_name = "LEGO Star Wars: The Complete Saga"
 title_id = "4C4107D7" # LA-2007
-hash = "6BE34440FDFD3BFD" # Default.xex
+#hash = "" # default.xex
 #media_id = "5E486FF7" http://redump.org/disc/38504
 
 [[patch]]

--- a/patches/4C4107F3 - LEGO Star Wars III The Clone Wars.patch.toml
+++ b/patches/4C4107F3 - LEGO Star Wars III The Clone Wars.patch.toml
@@ -1,6 +1,6 @@
 title_name = "LEGO Star Wars III: The Clone Wars" # 3
 title_id = "4C4107F3" # LA-2035
-hash = "3C9DCC41B7BAD2C8" # Default.xex
+#hash = "" # default.xex
 #media_id = "563D3E40" http://redump.org/disc/38506
 
 [[patch]]

--- a/patches/4D5307D1 - Project Gotham Racing 3.patch.toml
+++ b/patches/4D5307D1 - Project Gotham Racing 3.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Project Gotham Racing 3" # PGR
 title_id = "4D5307D1" # MS-2001
-hash = "27434388DD93EF6C" # default.xex
+#hash = "" # default.xex
 #media_id = ""
 
 [[patch]]

--- a/patches/4D5307D2 - Kameo Elements of Power.patch.toml
+++ b/patches/4D5307D2 - Kameo Elements of Power.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Kameo: Elements of Power"
 title_id = "4D5307D2" # MS-2002
-hash = "6E646E535A1F7E4D" # default.xex
+#hash = "" # default.xex
 #media_id = ""
 
 [[patch]]

--- a/patches/4D5307D3 - Perfect Dark Zero.patch.toml
+++ b/patches/4D5307D3 - Perfect Dark Zero.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Perfect Dark: Zero"
 title_id = "4D5307D3" # MS-2003
-hash = "1A03CDC040BC167C" # default.xex
+#hash = "" # default.xex
 #media_id = "41EEAFCB" http://redump.org/disc/11810
 
 [[patch]]

--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Blue Dragon"
 title_id = "4D5307DF" # MS-2015
-hash = "A219DC66FAE78ACF" # Disc 1/2/3, default.xex
+#hash = "" # Disc 1/2/3, default.xex
 #media_id = "3A702998" Disc 1, http://redump.org/disc/11826
 #media_id = "1D8CBD9D" Disc 2, http://redump.org/disc/11825
 #media_id = "05C08AC4" Disc 3, http://redump.org/disc/11824

--- a/patches/4D5307E6 - Halo 3.patch.toml
+++ b/patches/4D5307E6 - Halo 3.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Halo 3"
 title_id = "4D5307E6" # MS-2022
-hash = "F60C9314EB13F79F" # default.xex
+#hash = "" # default.xex
 #media_id = "699E0227" http://redump.org/disc/7749
 
 [[patch]]

--- a/patches/4D5307ED - Banjo-Kazooie Nuts & Bolts.patch.toml
+++ b/patches/4D5307ED - Banjo-Kazooie Nuts & Bolts.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Banjo-Kazooie: Nuts & Bolts" # And, N&B
 title_id = "4D5307ED" # MS-2029
-hash = "C6433BB2BA42398B" # default.xex
+#hash = "" # default.xex
 #media_id = "3E567DFF" http://redump.org/disc/11831
 
 [[patch]]

--- a/patches/4D5307F1 - Fable II (GOTY_Platinum Edition).patch.toml
+++ b/patches/4D5307F1 - Fable II (GOTY_Platinum Edition).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Fable II" # Fable 2 GOTY (Game Of The Year)/Platinum Edition
 title_id = "4D5307F1" # MS-2033
-hash = "DC37E03291273A05" # default.xex
+#hash = "" # default.xex
 #media_id = "716F0A0D" http://redump.org/disc/20202
 
 [[patch]]

--- a/patches/4D5307F2 - Viva Pinata.patch.toml
+++ b/patches/4D5307F2 - Viva Pinata.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Viva Piñata"
 title_id = "4D5307F2" # MS-2034
-hash = "0A6FB809F4B250D5" # default.xex
+#hash = "" # default.xex
 #media_id = "690B3287" http://redump.org/disc/11854
 
 [[patch]]

--- a/patches/4D5307F9 - Project Gotham Racing 4.patch.toml
+++ b/patches/4D5307F9 - Project Gotham Racing 4.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Project Gotham Racing 4" # PGR
 title_id = "4D5307F9" # MS-2041
-hash = "16160D0BACA111DD" # default.xex
+#hash = "" # default.xex
 #media_id = "5A381A4E" http://redump.org/disc/11813
 
 [[patch]]

--- a/patches/4D5307FA - Lost Odyssey.patch.toml
+++ b/patches/4D5307FA - Lost Odyssey.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Lost Odyssey"
 title_id = "4D5307FA" # MS-2042
-hash = "C11FC52E145E44A3" # Disc 1/2/3/4, default.xex
+#hash = "" # Disc 1/2/3/4, default.xex
 #media_id = "368DE6DD" Disc 1, http://redump.org/disc/11817
 #media_id = "1888BE4E" Disc 2, http://redump.org/disc/11818
 #media_id = "6DD59D08" Disc 3, http://redump.org/disc/11819

--- a/patches/4D53085B - Halo Reach.patch.toml
+++ b/patches/4D53085B - Halo Reach.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Halo: Reach"
 title_id = "4D53085B" # MS-2139
-hash = "FA1FAD680F1BCE8B" # default.xex
+#hash = "" # default.xex
 #media_id = "566C10D3" http://redump.org/disc/16109
 
 [[patch]]

--- a/patches/4D53085F - Viva Pinata Trouble in Paradise.patch.toml
+++ b/patches/4D53085F - Viva Pinata Trouble in Paradise.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Viva Piñata: Trouble in Paradise" # TIP
 title_id = "4D53085F" # MS-2143
-hash = "B6AB7E714A5904D3" # default.xex
+#hash = "" # default.xex
 #media_id = "76A44A5D" http://redump.org/disc/67404
 
 [[patch]]

--- a/patches/4D530877 - Halo 3 ODST.patch.toml
+++ b/patches/4D530877 - Halo 3 ODST.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Halo 3: ODST"
 title_id = "4D530877" # MS-2167
-hash = "D268A257B417331D" # default.xex
+#hash = "" # default.xex
 #media_id = "2299898F" http://redump.org/disc/12515
 
 [[patch]]

--- a/patches/4D53090E - Kinect Star Wars.patch.toml
+++ b/patches/4D53090E - Kinect Star Wars.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Kinect Star Wars"
 title_id = "4D53090E" # MS-2318
-hash = "1DA5376FD736C512" # default.xex
+#hash = "" # default.xex
 #media_id = "0967FCD4"
 
 [[patch]]

--- a/patches/4D5309B1 - Halo Combat Evolved Anniversary.patch.toml
+++ b/patches/4D5309B1 - Halo Combat Evolved Anniversary.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Halo: Combat Evolved Anniversary" # CE
 title_id = "4D5309B1" # MS-2481
-hash = "2E03AC6707362407" # default.xex
+#hash = "" # default.xex
 #media_id = "00394009" http://redump.org/disc/37086
 
 [[patch]]

--- a/patches/4D5309C9 - Forza Horizon.patch.toml
+++ b/patches/4D5309C9 - Forza Horizon.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Forza Horizon"
 title_id = "4D5309C9" # MS-2505
-hash = "F68A4156E4D07529" # default.xex
+#hash = "" # default.xex
 #media_id = "2B7A1346" http://redump.org/disc/84331
 
 [[patch]]

--- a/patches/4D5387E0 - Kameo Elements of Power (kiosk demo).patch.toml
+++ b/patches/4D5387E0 - Kameo Elements of Power (kiosk demo).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Kameo: Elements of Power" # Kiosk demo
 title_id = "4D5387E0" # MS-34784
-hash = "71D9578AE751EA85" # demos/Kameo/default.xex
+#hash = "" # demos/Kameo/default.xex
 #media_id = ""
 
 [[patch]]

--- a/patches/4D5387E9 - Kameo Elements of Power (demo).patch.toml
+++ b/patches/4D5387E9 - Kameo Elements of Power (demo).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Kameo: Elements of Power" # Demo
 title_id = "4D5387E9" # MS-34793
-hash = "62AC48C84352C119" # default.xex
+#hash = "" # default.xex
 #media_id = ""
 
 [[patch]]

--- a/patches/4E4D07D3 - Ridge Racer 6.patch.toml
+++ b/patches/4E4D07D3 - Ridge Racer 6.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Ridge Racer 6"
 title_id = "4E4D07D3" # NM-2003
-hash = "6394A8068C147C13" # default.xex
+#hash = "" # default.xex
 #media_id = "03F77EEF" http://redump.org/disc/57116
 
 [[patch]]

--- a/patches/534307E2 - Bionicle Heroes.patch.toml
+++ b/patches/534307E2 - Bionicle Heroes.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Bionicle Heroes"
 title_id = "534307E2" # SC-2018
-hash = "AB3306CA1BD3A605" # default.xex
+#hash = "" # default.xex
 #media_id = "39D1B5B2" http://redump.org/disc/16209
 
 [[patch]]

--- a/patches/5343080B - Batman Arkham Asylum GOTY.patch.toml
+++ b/patches/5343080B - Batman Arkham Asylum GOTY.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Batman: Arkham Asylum GOTY" # Game Of The Year
 title_id = "5343080B" # SC-2059
-hash = "5FFB2766CD47DA75" # default.xex
+#hash = "" # default.xex
 #media_id = "71D29B88" http://redump.org/disc/68344
 
 [[patch]]

--- a/patches/534507D6 - Sonic the Hedgehog (2006).patch.toml
+++ b/patches/534507D6 - Sonic the Hedgehog (2006).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Sonic the Hedgehog" # 2006
 title_id = "534507D6" # SE-2006
-hash = "B1EC26FA8D514291" # default.xex
+#hash = "" # default.xex
 #media_id = "7709C3E8" http://redump.org/disc/14270
 
 [[patch]]

--- a/patches/5345085A - Dreamcast Collection.patch.toml
+++ b/patches/5345085A - Dreamcast Collection.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Dreamcast Collection"
 title_id = "5345085A" # SE-2138
-hash = "E8D62D42361B5750" # default.xex
+#hash = "" # default.xex
 #media_id = "6876EE29" http://redump.org/disc/65367
 
 [[patch]]

--- a/patches/535107E4 - Final Fantasy XIII.patch.toml
+++ b/patches/535107E4 - Final Fantasy XIII.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Final Fantasy XIII" # 13
 title_id = "535107E4" # SQ-2020
-hash = "0591F9203EAE33B5" # Disc 1/2/3, default.xex
+#hash = "" # Disc 1/2/3, default.xex
 #media_id = "602A3E5A" Disc 1, http://redump.org/disc/12485
 #media_id = "40E764B6" Disc 2, http://redump.org/disc/12486
 #media_id = "0FE8E2F9" Disc 3, http://redump.org/disc/12487

--- a/patches/535107E8 - NIER.patch.toml
+++ b/patches/535107E8 - NIER.patch.toml
@@ -1,6 +1,6 @@
 title_name = "NIER"
 title_id = "535107E8" # SQ-2024
-hash = "42E20C1BD694FECF" # default.xex
+#hash = "" # default.xex
 #media_id = "507D2720" http://redump.org/disc/13314
 
 [[patch]]

--- a/patches/535107FA - Deus Ex Human Revolution Director's Cut.patch.toml
+++ b/patches/535107FA - Deus Ex Human Revolution Director's Cut.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Deus Ex: Human Revolution: Director's Cut"
 title_id = "535107FA" # SQ-2042
-hash = "3AF6BC6825FA30D0" # Disc 1/2, default.xex
+#hash = "" # Disc 1/2, default.xex
 #media_id = "7BBEB936" Disc 1, http://redump.org/disc/50503
 #media_id = "7C4137BE" Disc 2, http://redump.org/disc/50504
 

--- a/patches/53510806 - Final Fantasy XIII-2.patch.toml
+++ b/patches/53510806 - Final Fantasy XIII-2.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Final Fantasy XIII-2" # 13
 title_id = "53510806" # SQ-2054
-hash = "61530C817F5E67C9" # default.xex(?)
+#hash = "" # default.xex(?)
 #media_id = ""
 
 [[patch]]

--- a/patches/53510806 - Final Fantasy XIII-2.patch.toml
+++ b/patches/53510806 - Final Fantasy XIII-2.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Final Fantasy XIII-2" # 13
 title_id = "53510806" # SQ-2054
-#hash = "" # default.xex(?)
+#hash = "" # TODO: Add module filename
 #media_id = ""
 
 [[patch]]

--- a/patches/53518810 - Final Fantasy XIII-2 Demo.patch.toml
+++ b/patches/53518810 - Final Fantasy XIII-2 Demo.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Final Fantasy XIII-2 Demo" # 13
 title_id = "53518810" # SQ-34832
-hash = "DAE1E6C320020E2B" # default.xex
+#hash = "" # default.xex
 #media_id = "4835CB45"
 
 [[patch]]

--- a/patches/544307D5 - NINJA GAIDEN 2 (TU3).patch.toml
+++ b/patches/544307D5 - NINJA GAIDEN 2 (TU3).patch.toml
@@ -1,6 +1,6 @@
 title_name = "NINJA GAIDEN 2" # TU3
 title_id = "544307D5" # TC-2005
-hash = "D5054F1B851CD253" # default.xex
+#hash = "" # default.xex
 #media_id = "69F555CB" http://redump.org/disc/13299
 
 [[patch]]

--- a/patches/544307D5 - NINJA GAIDEN 2.patch.toml
+++ b/patches/544307D5 - NINJA GAIDEN 2.patch.toml
@@ -1,6 +1,6 @@
 title_name = "NINJA GAIDEN 2"
 title_id = "544307D5" # TC-2005
-hash = "5350C874028D7F6F" # default.xex
+#hash = "" # default.xex
 #media_id = "69F555CB" http://redump.org/disc/13299
 
 [[patch]]

--- a/patches/545107F1 - Ratatouille.patch.toml
+++ b/patches/545107F1 - Ratatouille.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Ratatouille"
 title_id = "545107F1" # TQ-2033
-hash = "529918FCA5600997" # DEFAULT.XEX
+#hash = "" # default.xex
 #media_id = "5F7B08F3"
 
 [[patch]]

--- a/patches/54510850 - SpongeBob - Truth or Square.patch.toml
+++ b/patches/54510850 - SpongeBob - Truth or Square.patch.toml
@@ -1,6 +1,6 @@
 title_name = "SpongeBob: Truth or Square" # Truth-Sq.
 title_id = "54510850" # TQ-2128
-hash = "9973E82C2AAB96E8" # DEFAULT.XEX
+#hash = "" # default.xex
 #media_id = "675568DB" http://redump.org/disc/14706
 
 [[patch]]

--- a/patches/54510866 - WWE All Stars.patch.toml
+++ b/patches/54510866 - WWE All Stars.patch.toml
@@ -1,6 +1,6 @@
 title_name = "WWE All Stars"
 title_id = "54510866" # TQ-2150
-hash = "E4550414FD6B4F94" # Default.xex
+#hash = "" # default.xex
 #media_id = "60CEF505" http://redump.org/disc/60662
 
 [[patch]]

--- a/patches/545407D4 - Amped 3.patch.toml
+++ b/patches/545407D4 - Amped 3.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Amped 3"
 title_id = "545407D4" # TT-2004
-hash = "B5ED27842F167674" # default.xex
+#hash = "" # default.xex
 #media_id = "2DFD68C2" http://redump.org/disc/7747
 
 [[patch]]

--- a/patches/545407EE - The Darkness.patch.toml
+++ b/patches/545407EE - The Darkness.patch.toml
@@ -1,6 +1,6 @@
 title_name = "The Darkness"
 title_id = "545407EE" # TT-2030
-hash = "29917FABA6FFCB1E" # default.xex
+#hash = "" # default.xex
 #media_id = "0F213645" http://redump.org/disc/11406
 
 [[patch]]

--- a/patches/545407F8 - Midnight Club Los Angeles Complete Edition.patch.toml
+++ b/patches/545407F8 - Midnight Club Los Angeles Complete Edition.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Midnight Club: Los Angeles" # MCLA, Complete Edition
 title_id = "545407F8" # TT-2040
-hash = "F6A6573D3F63A1C5" # default.xex
+#hash = "" # default.xex
 #media_id = "5940C9DB" http://redump.org/disc/64472/
 
 [[patch]]

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Red Dead Redemption" # Original, NTSC
 title_id = "5454082B" # TT-2091
-hash = "33C4335190AD0715" # default.xex, disc
+#hash = "" # default.xex, disc
 #hash = "" # default.xex, digital
 #media_id = "2AAB34E2" http://redump.org/disc/13298
 

--- a/patches/555307DC - Far Cry Instincts Predator.patch.toml
+++ b/patches/555307DC - Far Cry Instincts Predator.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Far Cry Instincts: Predator" # FC
 title_id = "555307DC" # US-2012
-hash = "3545B0D18EA51BC1" # default.xex
+#hash = "" # default.xex
 #media_id = "4971ECEF" http://redump.org/disc/16404
 
 [[patch]]

--- a/patches/584107D5 - Small Arms.patch.toml
+++ b/patches/584107D5 - Small Arms.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Small Arms"
 title_id = "584107D5" # XA-2005
-hash = "90C49E2E1336127C" # default.xex
+#hash = "" # default.xex
 #media_id = "5C6ABFE7"
 
 [[patch]]

--- a/patches/58410889 - Peggle.patch.toml
+++ b/patches/58410889 - Peggle.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Peggle"
 title_id = "58410889" # XA-2185
-hash = "D19F551B4CACA926" # default.xex
+#hash = "" # default.xex
 #media_id = "111272B2"
 
 [[patch]]

--- a/patches/584108A9 - Bean (GoldenEye 007).patch.toml
+++ b/patches/584108A9 - Bean (GoldenEye 007).patch.toml
@@ -1,9 +1,9 @@
 title_name = "Bean (GoldenEye 007)"
 title_id = "584108A9" # XA-2217
-hash = "DF251CA57C1B6E94" # default.xex (modified)
-#hash = "7B1AA31EA7ADF975" # Bean.xex (unmodified)
-#hash = "55CB99E83BC1FF2E" # Bean_debug.xex
-#hash = "82081F8E1AEE2D0E" # Bean_team.xex
+#hash = "" # default.xex (modified)
+#hash = "" # Bean.xex (unmodified)
+#hash = "" # Bean_debug.xex
+#hash = "" # Bean_team.xex
 #media_id = "00000000"
 
 [[patch]]

--- a/patches/584108D3 - Boogie Bunnies.patch.toml
+++ b/patches/584108D3 - Boogie Bunnies.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Boogie Bunnies"
 title_id = "584108D3" # XA-2259
-hash = "8E476ED3391F2B32" # default.xex
+#hash = "" # default.xex
 #media_id = "6AA3404F"
 
 [[patch]]

--- a/patches/58410908 - Gel Set & Match.patch.toml
+++ b/patches/58410908 - Gel Set & Match.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Gel: Set & Match" # And
 title_id = "58410908" # XA-2312
-hash = "E01A779FB78FB923" # default.xex
+#hash = "" # default.xex
 #media_id = "5DEAE719"
 
 [[patch]]

--- a/patches/5841090B - Doritos Dash of Destruction.patch.toml
+++ b/patches/5841090B - Doritos Dash of Destruction.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Doritos Dash of Destruction"
 title_id = "5841090B" # XA-2315
-hash = "27286D2621D28B09" # default.xex
+#hash = "" # default.xex
 #media_id = "4ED33D78"
 
 [[patch]]

--- a/patches/58410954 - Banjo-Kazooie.patch.toml
+++ b/patches/58410954 - Banjo-Kazooie.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Banjo-Kazooie"
 title_id = "58410954" # XA-2388
-hash = "19C54CE630DAB650" # default.xex
+#hash = "" # default.xex
 #media_id = "69C685B7"
 
 [[patch]]

--- a/patches/58410955 - Banjo-Tooie.patch.toml
+++ b/patches/58410955 - Banjo-Tooie.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Banjo-Tooie"
 title_id = "58410955" # XA-2389
-hash = "AB8ABE4E5536E8EE" # default.xex
+#hash = "" # default.xex
 #media_id = "65D27094"
 
 [[patch]]

--- a/patches/58410968 - Outrun Online Arcade.patch.toml
+++ b/patches/58410968 - Outrun Online Arcade.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Outrun™ Online Arcade"
 title_id = "58410968" # XA-2408
-hash = "F16C96458B72705B" # default.xex
+#hash = "" # default.xex
 #media_id = "3CB8E563"
 
 [[patch]]

--- a/patches/5841096A - Hydro Thunder Hurricane.patch.toml
+++ b/patches/5841096A - Hydro Thunder Hurricane.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Hydro Thunder Hurricane"
 title_id = "5841096A" # XA-2410
-hash = "615B4AA49E75CD5F" # default.xex
+#hash = "" # default.xex
 #media_id = "1F4C5091"
 
 [[patch]]

--- a/patches/58410A34 - Crazy Taxi.patch.toml
+++ b/patches/58410A34 - Crazy Taxi.patch.toml
@@ -1,7 +1,7 @@
 title_name = "Crazy Taxi"
 title_id = "58410A34" # XA-2612
-hash = "17EA4A64AEECAE89" # Content/0000000000000000/58410A34/000D0000/8CCAFCF0BCA37A5854932556831B08F3542CC94358/default.xex
-#hash = "E8D62D42361B5750" # default.xex
+#hash = "" # Content/0000000000000000/58410A34/000D0000/8CCAFCF0BCA37A5854932556831B08F3542CC94358/default.xex
+#hash = "" # default.xex
 #media_id = "26CE73AF" Crazy Taxi
 #media_id = "6876EE29" Dreamcast Collection, http://redump.org/disc/65367
 

--- a/patches/58410A39 - Space Channel 5 Part 2.patch.toml
+++ b/patches/58410A39 - Space Channel 5 Part 2.patch.toml
@@ -1,7 +1,7 @@
 title_name = "Space Channel 5 Part 2"
 title_id = "58410A39" # XA-2617
-hash = "5CC11F14C658F6E8" # Content/0000000000000000/58410A39/000D0000/B63BC2F5159BDE1A39A675C761D187E6A17FA81558/default.xex
-#hash = "E8D62D42361B5750" # default.xex
+#hash = "" # Content/0000000000000000/58410A39/000D0000/B63BC2F5159BDE1A39A675C761D187E6A17FA81558/default.xex
+#hash = "" # default.xex
 #media_id = "3C774097" Space Channel 5 Part 2
 #media_id = "6876EE29" Dreamcast Collection, http://redump.org/disc/65367
 

--- a/patches/58410A70 - Harm's Way.patch.toml
+++ b/patches/58410A70 - Harm's Way.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Harm's Way"
 title_id = "58410A70" # XA-2672
-hash = "E65B0F80FF844C49" # default.xex
+#hash = "" # default.xex
 #media_id = "336F22CD"
 
 [[patch]]

--- a/patches/584111E8 - State of Decay (TU5).patch.toml
+++ b/patches/584111E8 - State of Decay (TU5).patch.toml
@@ -1,6 +1,6 @@
 title_name = "State of Decay" # TU5
 title_id = "584111E8" # XA-4584
-#hash = "" # default.xex(?)
+#hash = "" # TODO: Add module filename
 #media_id = "6F32E742"
 
 [[patch]]

--- a/patches/584111F7 - Minecraft (XBLA, TU0).patch.toml
+++ b/patches/584111F7 - Minecraft (XBLA, TU0).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Minecraft" # XBLA, TU0
 title_id = "584111F7" # XA-4599
-hash = "ECCFA59A0ADA4E07" # default.xex
+#hash = "" # default.xex
 #media_id = "7CD33B56"
 
 [[patch]]

--- a/patches/5841124F - Doritos Crash Course 2.patch.toml
+++ b/patches/5841124F - Doritos Crash Course 2.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Doritos Crash Course 2"
 title_id = "5841124F" # XA-4687
-hash = "D90793F2A021796A" # default.xex
+#hash = "" # default.xex
 #media_id = "6FBC14D5"
 
 [[patch]]

--- a/patches/58411436 - Peggle 2.patch.toml
+++ b/patches/58411436 - Peggle 2.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Peggle 2"
 title_id = "58411436" # XA-5174
-hash = "E1A68BCCDE59F20C" # Default.xex
+#hash = "" # default.xex
 #media_id = "4906ADEC"
 
 [[patch]]


### PR DESCRIPTION
In preparation of the Gliniak's novel method of hash generation through .TEXT analysis, we're removing all old hashes which were reintroduced last week.

All hashes, including commented out ones on multi-disc or multi-executable files are being removed... They'll all need to be recalculated anyways. 