### PR TITLE
Hashes, Gears TUs, 16x AF, RDR Housekeeping

### DIFF
--- a/patches/415608AF - GoldenEye 007 Reloaded.patch.toml
+++ b/patches/415608AF - GoldenEye 007 Reloaded.patch.toml
@@ -1,6 +1,6 @@
 title_name = "GoldenEye 007: Reloaded" # GE
 title_id = "415608AF" # AV-2223
-#hash = "" # default.xex
+hash = "065D6021C0BDD535" # default.xex
 #media_id = "40583A82" http://redump.org/disc/38456
 
 [[patch]]
@@ -12,3 +12,15 @@ title_id = "415608AF" # AV-2223
     [[patch.be32]]
         address = 0x8248cb40
         value = 0x48000db8
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8240ef40
+        value = 0x39200010
+    [[patch.be32]]
+        address = 0x826139f4
+        value = 0x38a00010

--- a/patches/41560904 - Transformers-Rise of The Dark Spark.patch.toml
+++ b/patches/41560904 - Transformers-Rise of The Dark Spark.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Transformers: Rise of The Dark Spark"
 title_id = "41560904" # AV-2308
-#hash = "" # default.xex
+hash = "5821E90CE3C7FBB3" # default.xex
 #media_id = "50D83F2D" http://redump.org/disc/41959
 
 [[patch]]

--- a/patches/43430830 - Lost Planet 3.patch.toml
+++ b/patches/43430830 - Lost Planet 3.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Lost Planet 3"
 title_id = "43430830" # CC-2096
-#hash = "" # default.xex
+hash = "3F74E86B6D9AC1C8" # default.xex
 #media_id = "09C0B498" http://redump.org/disc/40497
 
 [[patch]]

--- a/patches/45410850 - Mirror's Edge.patch.toml
+++ b/patches/45410850 - Mirror's Edge.patch.toml
@@ -1,7 +1,8 @@
 title_name = "Mirror's Edge"
 title_id = "45410850" # EA-2128
-#hash = "" # default.xex
+hash = "25AA0820DF95AA47" # default.xex
 #media_id = "426CA5A2" http://redump.org/disc/11415
+#media_id = "214A9845"
 
 [[patch]]
     name = "Unlock FPS"

--- a/patches/454108EF - Bulletstorm.patch.toml
+++ b/patches/454108EF - Bulletstorm.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Bulletstorm"
 title_id = "454108EF" # EA-2287
-#hash = "" # default.xex
+hash = "D61EAED8BB6A1365" # default.xex
 #media_id = "1D93E609" http://redump.org/disc/21494
 
 [[patch]]

--- a/patches/45410916 - Alice Madness Returns.patch.toml
+++ b/patches/45410916 - Alice Madness Returns.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Alice: Madness Returns"
 title_id = "45410916" # EA-2326
-#hash = "" # default.xex
+hash = "2FD7D2F9D7F51AEA" # default.xex
 #media_id = "31C4B45C" http://redump.org/disc/38414
 
 [[patch]]

--- a/patches/4D53082D - Gears of War 2 (TU6).patch.toml
+++ b/patches/4D53082D - Gears of War 2 (TU6).patch.toml
@@ -1,7 +1,7 @@
 title_name = "Gears of War 2" # TU6
 title_id = "4D53082D" # MS-2093
-#hash = "" # default.xex
-#media_id = "22AB4F7C"
+hash = "62547A005C0420D2" # default.xex
+#media_id = "33FCE762"
 
 [[patch]]
     name = "Unlock FPS"
@@ -48,6 +48,7 @@ title_id = "4D53082D" # MS-2093
 
 [[patch]]
     name = "Disable Motion Blur"
+	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
     author = "illusion, boma"
     is_enabled = false
 
@@ -63,3 +64,46 @@ title_id = "4D53082D" # MS-2093
     [[patch.be32]]
         address = 0x8281e3b4
         value = 0x38a00010
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827be894
+        value = 0x39400000
+
+[[patch]]
+    name = "Disable Depth of Field"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822e3910
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x82422768
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x824f2234
+        value = 0x39200000
+    [[patch.be32]]
+        address = 0x824f2374
+        value = 0x39600000
+
+[[patch]]
+    name = "Disable Bloom"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822e3904
+        value = 0x39400000
+    [[patch.be32]]
+        address = 0x824f2240
+        value = 0x39400000
+    [[patch.be32]]
+        address = 0x824f2380
+        value = 0x39600000

--- a/patches/4D53082D - Gears of War 2 (TU6).patch.toml
+++ b/patches/4D53082D - Gears of War 2 (TU6).patch.toml
@@ -48,7 +48,7 @@ hash = "62547A005C0420D2" # default.xex
 
 [[patch]]
     name = "Disable Motion Blur"
-	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
+    desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
     author = "illusion, boma"
     is_enabled = false
 

--- a/patches/4D53082D - Gears of War 2.patch.toml
+++ b/patches/4D53082D - Gears of War 2.patch.toml
@@ -1,7 +1,7 @@
 title_name = "Gears of War 2"
 title_id = "4D53082D" # MS-2093
-#hash = "" # default.xex
-#media_id = "22AB4F7C"
+hash = "BDB97753374D520A" # default.xex
+#media_id = "33FCE762"
 
 [[patch]]
     name = "Unlock FPS"
@@ -48,6 +48,7 @@ title_id = "4D53082D" # MS-2093
 
 [[patch]]
     name = "Disable Motion Blur"
+	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
     author = "illusion"
     is_enabled = false
 
@@ -63,3 +64,46 @@ title_id = "4D53082D" # MS-2093
     [[patch.be32]]
         address = 0x8280e7fc
         value = 0x38a00010
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827b817c
+        value = 0x39400000
+
+[[patch]]
+    name = "Disable Depth of Field"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823e1720
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x824eceec
+        value = 0x39200000
+    [[patch.be32]]
+        address = 0x824ed06c
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x824ed0b0
+        value = 0x39600000
+
+[[patch]]
+    name = "Disable Bloom"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824ecef8
+        value = 0x39400000
+    [[patch.be32]]
+        address = 0x824ed078
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x824ed0a4
+        value = 0x39400000

--- a/patches/4D53082D - Gears of War 2.patch.toml
+++ b/patches/4D53082D - Gears of War 2.patch.toml
@@ -48,7 +48,7 @@ hash = "BDB97753374D520A" # default.xex
 
 [[patch]]
     name = "Disable Motion Blur"
-	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
+    desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
     author = "illusion"
     is_enabled = false
 

--- a/patches/4D5308AB - Gears of War 3 (TU6).patch.toml
+++ b/patches/4D5308AB - Gears of War 3 (TU6).patch.toml
@@ -1,7 +1,9 @@
 title_name = "Gears of War 3" # TU6
 title_id = "4D5308AB" # MS-2219
-#hash = "" # default.xex
-#media_id = "4C93A17D"
+hash = "7775898137CE1CE3" # default.xex
+#media_id = "02EEE060"
+#media_id = "6EF14DF9"
+#media_id = "58122AD6"
 
 [[patch]]
     name = "Unlock FPS"
@@ -53,6 +55,19 @@ title_id = "4D5308AB" # MS-2219
         value = 0x39600000
 
 [[patch]]
+    name = "Disable Motion Blur"
+	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82440f60
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x827b4c9c
+        value = 0x39600000
+
+[[patch]]
     name = "16x Anisotropic Filtering"
     author = "boma"
     is_enabled = false
@@ -78,13 +93,22 @@ title_id = "4D5308AB" # MS-2219
         value = 0x38800004
 
 [[patch]]
-    name = "Disable Motion Blur"
+    name = "Disable Depth of Field"
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82440f60
+        address = 0x8237271c
         value = 0x39600000
     [[patch.be32]]
-        address = 0x827b4c9c
+        address = 0x824caf60
         value = 0x39600000
+
+[[patch]]
+    name = "Disable Bloom"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82372718
+        value = 0x39400000

--- a/patches/4D5308AB - Gears of War 3 (TU6).patch.toml
+++ b/patches/4D5308AB - Gears of War 3 (TU6).patch.toml
@@ -56,7 +56,7 @@ hash = "7775898137CE1CE3" # default.xex
 
 [[patch]]
     name = "Disable Motion Blur"
-	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
+    desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D5308AB - Gears of War 3.patch.toml
+++ b/patches/4D5308AB - Gears of War 3.patch.toml
@@ -57,7 +57,7 @@ hash = "EF4AD5E9DD1982ED" # default.xex
 
 [[patch]]
     name = "Disable Motion Blur"
-	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
+    desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D5308AB - Gears of War 3.patch.toml
+++ b/patches/4D5308AB - Gears of War 3.patch.toml
@@ -1,7 +1,10 @@
 title_name = "Gears of War 3"
 title_id = "4D5308AB" # MS-2219
-#hash = "" # default.xex
+hash = "EF4AD5E9DD1982ED" # default.xex
 #media_id = "4C93A17D"
+#media_id = "02EEE060"
+#media_id = "6EF14DF9"
+#media_id = "58122AD6"
 
 [[patch]]
     name = "Unlock FPS"
@@ -53,6 +56,19 @@ title_id = "4D5308AB" # MS-2219
         value = 0x39600000
 
 [[patch]]
+    name = "Disable Motion Blur"
+	desc = "Solves most ghosting and artifacting caused by quickly panning cameras."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82430640
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x827a2bcc
+        value = 0x39600000
+
+[[patch]]
     name = "16x Anisotropic Filtering"
     author = "boma"
     is_enabled = false
@@ -78,13 +94,22 @@ title_id = "4D5308AB" # MS-2219
         value = 0x38800004
 
 [[patch]]
-    name = "Disable Motion Blur"
+    name = "Disable Depth of Field"
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82430640
+        address = 0x824baa50
         value = 0x39600000
     [[patch.be32]]
-        address = 0x827a2bcc
+        address = 0x82593dc4
         value = 0x39600000
+
+[[patch]]
+    name = "Disable Bloom"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82593dc0
+        value = 0x39400000

--- a/patches/4D530A26 - Gears of War Judgment (TU4).patch.toml
+++ b/patches/4D530A26 - Gears of War Judgment (TU4).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Gears of War: Judgment"
 title_id = "4D530A26" # MS-2598
-hash = "8429D0AE190C10DB" # default.xex
+hash = "013148141A27D4C7" # default.xex
 #media_id = "3528321A" # Disc (US EU) http://redump.org/disc/57311
 #media_id = "250B2C78" # Disc (EU)    http://redump.org/disc/65904
 #media_id = "6DCAF3C2" # XBLA (87daed863476d86f36a9c740aa6514cfd19d4e9d, da-DK en-AU en-CA en-HK en-IN en-NZ en-SG en-US en-ZA es-AR es-CL es-CO es-MX fi-FI fr-BE fr-CA ko-KR nb-NO nl-BE nl-NL pl-PL pt-PT)
@@ -16,20 +16,20 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x8255de08
+        address = 0x8255e220
         value = 0x60000000
     [[patch.be8]]
-        address = 0x82bdc65b
+        address = 0x82bdf113
         value = 0x01
 
 [[patch]]
     name = "Disable Lens Flares"
     desc = "Fixes unoccluded bright lights on-screen."
-    author = "illusion"
+    author = "illusion, boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x8288e120
+        address = 0x8288eb50
         value = 0x39400000
 
 [[patch]]
@@ -39,8 +39,8 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x8234c778
-        value = 0x39600000
+        address = 0x8234c670
+        value = 0x39200000
 
 [[patch]]
     name = "16x Anisotropic Filtering"
@@ -48,26 +48,20 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82999954
+        address = 0x8299b564
         value = 0x38a00010
 
 [[patch]]
     name = "Resolution Scaling Fix / Disable All Post-Processing"
-    desc = "Dramatically changes the overall look of the game, but fixes all edge-detection overcorrection and color smearing."
+    desc = "Dramatically changes the overall look of the game, but fixes all edge-detection overcorrection and color smearing when upscaling."
     author = "boma"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x827e363c
-        value = 0x38a00000
-    [[patch.be32]]
-        address = 0x827e3810
-        value = 0x38a00000
-    [[patch.be32]]
-        address = 0x827e3970
-        value = 0x38800004
+    [[patch.be16]]
+        address = 0x827e50ec
+        value = 0x4800
     [[patch.be32]] # nop finishing render pass from branching to temporal AA resolve
-        address = 0x827e392c
+        address = 0x827e42a4
         value = 0x60000000
 
 [[patch]]
@@ -77,10 +71,10 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x824297fc
+        address = 0x82428e94
         value = 0x39400000
     [[patch.be32]]
-        address = 0x8242b598
+        address = 0x8242ac30
         value = 0x39400000
 
 [[patch]]
@@ -89,10 +83,10 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x824427a8
+        address = 0x82441eb0
         value = 0x39600000
     [[patch.be32]]
-        address = 0x827cbd8c
+        address = 0x827ccc84
         value = 0x39600000
 
 [[patch]]
@@ -101,10 +95,10 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x824d79a8
+        address = 0x824d7c58
         value = 0x39600000
     [[patch.be32]]
-        address = 0x825b70dc
+        address = 0x825b747c
         value = 0x39600000
 
 [[patch]]
@@ -113,5 +107,5 @@ hash = "8429D0AE190C10DB" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825b70d8
+        address = 0x825b7478
         value = 0x39400000

--- a/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (GOTY, Disc 1).patch.toml
@@ -1,24 +1,11 @@
 title_name = "Red Dead Redemption" # GOTY/Game Of The Year, Disc 1
 title_id = "5454082B" # TT-2091
-#hash = "" # default.xex
+hash = "C46F07B398560962" # default.xex
 #media_id = "3EE87B76" http://redump.org/disc/58711
 
 [[patch]]
-    name = "Skip Intro"
-    desc = "Skips legal and intro videos."
-    author = "illusion"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x8278f6b0
-        value = 0x480001a0 # b 0x8278f850
-    [[patch.be32]]
-        address = 0x8278f850
-        value = 0x3b600001 # li r27,0x1
-
-[[patch]]
     name = "Unlock FPS"
-    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    desc = "Increases vsync target to 60 FPS. Additionally, framerates higher than the 64 FPS cap are unlocked but vsync must be set to false in the Xenia config. Be advised, due to aggressive double buffering, keeping vsync enabled will result in common drops to 30 FPS whenever there are performance dips."
     author = "boma"
     is_enabled = false
 
@@ -78,6 +65,16 @@ title_id = "5454082B" # TT-2091
         value = 0x38e00001
 
 [[patch]]
+    name = "Disable Sun Flare"
+    desc = "This prevents the sun flare effect, which clips through buildings and props, from rendering. May also partially remedy flashing and image exposure issues that arise when upscaling."
+    author = "emoose"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x827833b4
+        value = 0x4800
+
+[[patch]]
     name = "No Trees - Performance Mode"
     desc = "Prevents trees and all other foliage from rendering. Provides a substantial performance boost."
     author = "boma"
@@ -116,23 +113,17 @@ title_id = "5454082B" # TT-2091
         value = 0x39600001
 
 [[patch]]
-    name = "Disable SSAO"
-    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
-    author = "boma"
+    name = "Skip Intro"
+    desc = "Skips legal and intro videos."
+    author = "illusion"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x822fcb40
-        value = 0x48000114
-
-[[patch]]
-    name = "Skip Intro Rockstar Movie"
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be8]]
-        address = 0x8278f56c
-        value = 0x41
+        address = 0x8278f6b0
+        value = 0x480001a0 # b 0x8278f850
+    [[patch.be32]]
+        address = 0x8278f850
+        value = 0x3b600001 # li r27,0x1
 
 [[patch]]
     name = "Alternative Script Timing & Asset Garbage Collection"
@@ -203,13 +194,3 @@ title_id = "5454082B" # TT-2091
     [[patch.be32]]
         address = 0x825b9dd8
         value = 0x900a0000
-
-[[patch]]
-    name = "Disable Sun Flare"
-    desc = "Sun flare effect can clip through buildings when playing with increased resolutions, this prevents the effect from rendering"
-    author = "emoose"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x827833b4
-        value = 0x4800

--- a/patches/5454082B - Red Dead Redemption (GOTY, Disc 2).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (GOTY, Disc 2).patch.toml
@@ -1,11 +1,11 @@
 title_name = "Red Dead Redemption" # GOTY/Game Of The Year, Disc 2
 title_id = "5454082B" # TT-2091
-#hash = "" # default.xex
-#media_id = "3EE87B76" http://redump.org/disc/58711
+hash = "EAE1A29200C7C15C" # default.xex
+#media_id = "26302E11" http://redump.org/disc/58711
 
 [[patch]]
     name = "Unlock FPS"
-    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    desc = "Increases vsync target to 60 FPS. Additionally, framerates higher than the 64 FPS cap are unlocked but vsync must be set to false in the Xenia config. Be advised, due to aggressive double buffering, keeping vsync enabled will result in common drops to 30 FPS whenever there are performance dips."
     author = "boma"
     is_enabled = false
 
@@ -65,6 +65,16 @@ title_id = "5454082B" # TT-2091
         value = 0x38e00001
 
 [[patch]]
+    name = "Disable Sun Flare"
+    desc = "This prevents the sun flare effect, which clips through buildings and props, from rendering. May also partially remedy flashing and image exposure issues that arise when upscaling."
+    author = "emoose, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x82782b4c
+        value = 0x4800
+
+[[patch]]
     name = "No Trees - Performance Mode"
     desc = "Prevents trees and all other foliage from rendering. Provides a substantial performance boost."
     author = "boma"
@@ -103,23 +113,17 @@ title_id = "5454082B" # TT-2091
         value = 0x39600001
 
 [[patch]]
-    name = "Disable SSAO"
-    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
-    author = "boma"
+    name = "Skip Intro"
+    desc = "Skips legal and intro videos."
+    author = "illusion, boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x822fcc40
-        value = 0x48000114
-
-[[patch]]
-    name = "Skip Intro Rockstar Movie"
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be8]]
-        address = 0x8278ede4
-        value = 0x41
+        address = 0x8278ef28
+        value = 0x480001a0 # b 0x8278f0c8
+    [[patch.be32]]
+        address = 0x8278f0c8
+        value = 0x3b600001 # li r27,0x1
 
 [[patch]]
     name = "Alternative Script Timing & Asset Garbage Collection"

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC).patch.toml
@@ -1,28 +1,11 @@
 title_name = "Red Dead Redemption" # Original, NTSC
 title_id = "5454082B" # TT-2091
-#hash = "" # default.xex, disc
-#hash = "" # default.xex, digital
+hash = "94A999EAFF6AB07B" # default.xex
 #media_id = "2AAB34E2" http://redump.org/disc/13298
 
 [[patch]]
-    name = "Skip Intro"
-    desc = "Skips legal and intro videos."
-    author = "illusion"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82770958
-        value = 0x480001a0 # b 0x82770af8
-    [[patch.be32]]
-        address = 0x82770af8
-        value = 0x3b600001 # li r27,0x1
-    [[patch.be32]]
-        address = 0x82770afc
-        value = 0x9b7f000d # stb r27,0xd(r31)
-
-[[patch]]
     name = "Unlock FPS"
-    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    desc = "Increases vsync target to 60 FPS. Additionally, framerates higher than the 64 FPS cap are unlocked but vsync must be set to false in the Xenia config. Be advised, due to aggressive double buffering, keeping vsync enabled will result in common drops to 30 FPS whenever there are performance dips."
     author = "boma"
     is_enabled = false
 
@@ -82,6 +65,16 @@ title_id = "5454082B" # TT-2091
         value = 0x38e00001
 
 [[patch]]
+    name = "Disable Sun Flare"
+    desc = "This prevents the sun flare effect, which clips through buildings and props, from rendering. May also partially remedy flashing and image exposure issues that arise when upscaling."
+    author = "emoose, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x82766bac
+        value = 0x4800
+
+[[patch]]
     name = "No Trees - Performance Mode"
     desc = "Prevents trees and all other foliage from rendering. Provides a substantial performance boost."
     author = "boma"
@@ -120,23 +113,20 @@ title_id = "5454082B" # TT-2091
         value = 0x39600001
 
 [[patch]]
-    name = "Disable SSAO"
-    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
-    author = "boma"
+    name = "Skip Intro"
+    desc = "Skips legal and intro videos."
+    author = "illusion"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x822fafe8
-        value = 0x48000114
-
-[[patch]]
-    name = "Skip Intro Rockstar Movie"
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be8]]
-        address = 0x82770814
-        value = 0x41
+        address = 0x82770958
+        value = 0x480001a0 # b 0x82770af8
+    [[patch.be32]]
+        address = 0x82770af8
+        value = 0x3b600001 # li r27,0x1
+    [[patch.be32]]
+        address = 0x82770afc
+        value = 0x9b7f000d # stb r27,0xd(r31)
 
 [[patch]]
     name = "Alternative Script Timing & Asset Garbage Collection"

--- a/patches/5454082B - Red Dead Redemption (Original, NTSC, TU9).patch.toml
+++ b/patches/5454082B - Red Dead Redemption (Original, NTSC, TU9).patch.toml
@@ -1,11 +1,11 @@
 title_name = "Red Dead Redemption" # Original, NTSC, TU9
 title_id = "5454082B" # TT-2091
-#hash = "" # default.xex, disc
+hash = "1A284CDE0A9F0CF8" # default.xex
 #media_id = "2AAB34E2" http://redump.org/disc/13298
 
 [[patch]]
     name = "Unlock FPS"
-    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    desc = "Increases vsync target to 60 FPS. Additionally, framerates higher than the 64 FPS cap are unlocked but vsync must be set to false in the Xenia config. Be advised, due to aggressive double buffering, keeping vsync enabled will result in common drops to 30 FPS whenever there are performance dips."
     author = "boma"
     is_enabled = false
 
@@ -65,6 +65,16 @@ title_id = "5454082B" # TT-2091
         value = 0x38e00001
 
 [[patch]]
+    name = "Disable Sun Flare"
+    desc = "This prevents the sun flare effect, which clips through buildings and props, from rendering. May also partially remedy flashing and image exposure issues that arise when upscaling."
+    author = "emoose, boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x82754c14
+        value = 0x4800
+
+[[patch]]
     name = "No Trees - Performance Mode"
     desc = "Prevents trees and all other foliage from rendering. Provides a substantial performance boost."
     author = "boma"
@@ -103,23 +113,17 @@ title_id = "5454082B" # TT-2091
         value = 0x39600001
 
 [[patch]]
-    name = "Disable SSAO"
-    desc = "Probably won't improve overall performance but may help with graphical artifacts when upscaling."
-    author = "boma"
+    name = "Skip Intro"
+    desc = "Skips legal and intro videos."
+    author = "illusion, boma"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x822fc4a8
-        value = 0x48000114
-
-[[patch]]
-    name = "Skip Intro Rockstar Movie"
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be8]]
-        address = 0x82760adc
-        value = 0x41
+        address = 0x82760c20
+        value = 0x480001a0 # b 0x82760dc0
+    [[patch.be32]]
+        address = 0x82760dc0
+        value = 0x3b600001 # li r27,0x1
 
 [[patch]]
     name = "Alternative Script Timing & Asset Garbage Collection"

--- a/patches/5454085D - Bioshock Infinite.patch.toml
+++ b/patches/5454085D - Bioshock Infinite.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Bioshock Infinite"
 title_id = "5454085D" # TT-2141
-#hash = "" # default.xex
+hash = "F965DFB1F254E4E2" # default.xex
 #media_id = "7F5C4901"
 
 [[patch]]

--- a/patches/565707D0 - Lollipop Chainsaw (Premium Edition).patch.toml
+++ b/patches/565707D0 - Lollipop Chainsaw (Premium Edition).patch.toml
@@ -1,6 +1,6 @@
 title_name = "Lollipop Chainsaw" # Premium Edition
 title_id = "565707D0" # VW-2000
-#hash = "" # default.xex
+hash = "788B0C3E7B074F18" # default.xex
 #media_id = "3759EFF2" http://redump.org/disc/65899
 
 [[patch]]

--- a/patches/565707D0 - Lollipop Chainsaw.patch.toml
+++ b/patches/565707D0 - Lollipop Chainsaw.patch.toml
@@ -1,6 +1,6 @@
 title_name = "Lollipop Chainsaw"
 title_id = "565707D0" # VW-2000
-#hash = "" # default.xex
+hash = "9FEE77798A2E765C" # default.xex
 #media_id = "31BE13D9" http://redump.org/disc/35948
 
 [[patch]]


### PR DESCRIPTION
- Updated UE3 hashes
- Add bloom  & dof patches for Gears; TU parity
- GoldenEye reloaded hash & 16x af
- RDR housekeeping (remove faulty ssao patch, add vsync disclaimer, remove old no-intro, convert sun flare to all ver, reorganize patch order)