### PR TITLE
UE3 Games 2006-2010: "Black Shading" Dynamic Lighting Artifacts

### DIFF
--- a/patches/45410850 - Mirror's Edge.patch.toml
+++ b/patches/45410850 - Mirror's Edge.patch.toml
@@ -20,6 +20,19 @@ hash = "25AA0820DF95AA47" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "Dynamic Lighting & Shadows Shading Fix"
+    desc = "Solves most dynamic lighting artifacts, like splotchy skin complexion & invisible hands and feet, caused by an issue with MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823aa2e0
+        value = 0x39200000
+    [[patch.be32]]
+        address = 0x823aa350
+        value = 0x39200000
+
+[[patch]]
     name = "Disable Lens Flares"
     desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"

--- a/patches/4D5307D5 - Gears of War (TU5).patch.toml
+++ b/patches/4D5307D5 - Gears of War (TU5).patch.toml
@@ -1,17 +1,30 @@
 title_name = "Gears Of War" # TU5
 title_id = "4D5307D5" # MS-2005
-#hash = "" # default.xex
+hash = "34849A59634915F6" # default.xex
 #media_id = "76E9DF5B" # Disc (USA, Europe): http://redump.org/disc/7745
 
 [[patch]]
     name = "60 FPS"
-    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    desc = "Increases the default vsync target to 60 FPS. Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config, however that can potentially case timing-related physics and audio issues above 100 FPS."
     author = "boma"
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x82250ddb
+        address = 0x82250ddb # D3DPRESENT_INTERVAL_ONE
         value = 0x01
+
+[[patch]]
+    name = "Black Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82f9779b # GTilingMode = 0
+        value = 0x00
+    [[patch.be8]]
+        address = 0x82f97733 # GUseTilingCode = FALSE
+        value = 0x00
 
 [[patch]]
     name = "Disable Motion Blur"
@@ -42,4 +55,4 @@ title_id = "4D5307D5" # MS-2005
 
     [[patch.be32]]
         address = 0x8249d4d4
-        value = 0x38a00008
+        value = 0x38a00008 # li r5, 8

--- a/patches/4D5307D5 - Gears of War.patch.toml
+++ b/patches/4D5307D5 - Gears of War.patch.toml
@@ -1,17 +1,30 @@
 title_name = "Gears Of War"
 title_id = "4D5307D5" # MS-2005
-#hash = "" # default.xex
+hash = "1B591620508434A2" # default.xex
 #media_id = "76E9DF5B" # Disc (USA, Europe): http://redump.org/disc/7745
 
 [[patch]]
     name = "60 FPS"
-    desc = "Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config."
+    desc = "Increases the default vsync target to 60 FPS. Framerates higher than 60 FPS require vsync to be changed from true to false in the Xenia config, however that can potentially case timing-related physics and audio issues above 100 FPS."
     author = "boma"
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x8223e7bb
+        address = 0x8223e7bb # D3DPRESENT_INTERVAL_ONE
         value = 0x01
+
+[[patch]]
+    name = "Black Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82bb6bbb # GTilingMode = 0
+        value = 0x00
+    [[patch.be8]]
+        address = 0x82bb6b53 # GUseTilingCode = FALSE
+        value = 0x00
 
 [[patch]]
     name = "Disable Motion Blur"
@@ -23,7 +36,7 @@ title_id = "4D5307D5" # MS-2005
         value = 0x4800
 
 [[patch]]
-    name = "Disable Most Post-Processing"
+    name = "Disable All Post-Processing"
     author = "illusion, boma"
     is_enabled = false
 
@@ -42,4 +55,4 @@ title_id = "4D5307D5" # MS-2005
 
     [[patch.be32]]
         address = 0x82487484
-        value = 0x38a00008
+        value = 0x38a00008 # li r5, 8

--- a/patches/4D5707D7 - Blacksite.patch.toml
+++ b/patches/4D5707D7 - Blacksite.patch.toml
@@ -1,0 +1,38 @@
+title_name = "Blacksite Area 51"
+title_id = "4D5707D7" # MS-2005
+hash = "2DB7B2CDD4107BDC" # default.xex
+#media_id = "76E9DF5B" # Disc (USA, Europe): http://redump.org/disc/7745
+
+[[patch]]
+    name = "Dynamic Lighting & Shadows Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x835cd763 # GTilingMode = 0
+        value = 0x00
+    [[patch.be8]]
+        address = 0x835cd6fb # GUseTilingCode = FALSE
+        value = 0x00
+
+[[patch]]
+    name = "Disable All Post-Processing"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x8258b66c
+        value = 0x4800
+    [[patch.be16]]
+        address = 0x82695714
+        value = 0x4800
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825cf7d4
+        value = 0x38a00010 # li r5, 0x10

--- a/patches/4D5707D7 - Blacksite.patch.toml
+++ b/patches/4D5707D7 - Blacksite.patch.toml
@@ -1,7 +1,7 @@
 title_name = "Blacksite Area 51"
-title_id = "4D5707D7" # MS-2005
+title_id = "4D5707D7" # MW-2007
 hash = "2DB7B2CDD4107BDC" # default.xex
-#media_id = "76E9DF5B" # Disc (USA, Europe): http://redump.org/disc/7745
+#media_id = "686320E3" # Disc (USA, Europe): http://redump.org/disc/12355
 
 [[patch]]
     name = "Dynamic Lighting & Shadows Shading Fix"

--- a/patches/4D5707DB - Unreal Tournament 3.patch.toml
+++ b/patches/4D5707DB - Unreal Tournament 3.patch.toml
@@ -17,6 +17,16 @@ hash = "5E6434A23E7BA4AE" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "Dynamic Lighting & Shadows Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824D4198
+        value = 0x39200000
+
+[[patch]]
     name = "16x Anisotropic Filtering"
     author = "boma"
     is_enabled = false

--- a/patches/4D5707DF - TNA Impact (TU1).patch.toml
+++ b/patches/4D5707DF - TNA Impact (TU1).patch.toml
@@ -1,0 +1,17 @@
+title_name = "TNA Impact!" # TU1
+title_id = "4D5707DF" # MW-2015
+hash = "4C67CACD08FD5F08" # default.xex
+#media_id = "37AE817A", # Disc (USA, Europe): http://redump.org/disc/57591
+
+[[patch]]
+    name = "Dynamic Lighting & Shadows Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x83355513 # GTilingMode = 0
+        value = 0x00
+    [[patch.be8]]
+        address = 0x833553bb # GUseTilingCode = FALSE
+        value = 0x00

--- a/patches/4E4D080B - Magnacarta2.patch.toml
+++ b/patches/4E4D080B - Magnacarta2.patch.toml
@@ -4,6 +4,7 @@ hash = "B4CC5A66F752EBC3" # default.xex
 #media_id = [
 #    "60DA537D", # Disc 1 (USA, Europe): http://redump.org/disc/13307
 #    "5DB3BBBC", # Disc 2 (USA, Europe): http://redump.org/disc/13308
+#]
 
 [[patch]]
     name = "60 FPS"

--- a/patches/4E4D080B - Magnacarta2.patch.toml
+++ b/patches/4E4D080B - Magnacarta2.patch.toml
@@ -1,0 +1,47 @@
+title_name = "Magnacarta 2"
+title_id = "4E4D080B" # NM-2059
+hash = "B4CC5A66F752EBC3" # default.xex
+#media_id = [
+#    "60DA537D", # Disc 1 (USA, Europe): http://redump.org/disc/13307
+#    "5DB3BBBC", # Disc 2 (USA, Europe): http://redump.org/disc/13308
+
+[[patch]]
+    name = "60 FPS"
+    desc = "Increases the default vsync target to 60 FPS. Disabling vsync in Xenia config for over 60 FPS is not recommended as it causes numerous timing-related gameplay issues."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8237bfef # D3DPRESENT_INTERVAL_ONE
+        value = 0x01
+
+[[patch]]
+    name = "Dynamic Lighting & Shadows Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8321bd2b # GTilingMode = 0
+        value = 0x00
+    [[patch.be8]]
+        address = 0x8321bcc3 # GUseTilingCode = FALSE
+        value = 0x00
+
+[[patch]]
+    name = "Disable Most Post-Processing"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x824289e0
+        value = 0x4800
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8244a5d0
+        value = 0x38a00010 # li r5, 0x10

--- a/patches/5451083B - 50 Cent Blood on the Sand.patch.toml
+++ b/patches/5451083B - 50 Cent Blood on the Sand.patch.toml
@@ -1,6 +1,6 @@
 title_name = "50 Cent: Blood on the Sand" # BoTS
 title_id = "5451083B" # TQ-2107
-#hash = "" # default.xex
+hash = "355BF86D7238F120" # default.xex
 #media_id = "6FF4F789" # Disc (USA, Europe): http://redump.org/disc/14040
 
 [[patch]]
@@ -10,8 +10,30 @@ title_id = "5451083B" # TQ-2107
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x82316c9b
+        address = 0x82316c9b # D3DPRESENT_INTERVAL_ONE
         value = 0x01
+
+[[patch]]
+    name = "Dynamic Lighting & Shadows Shading Fix"
+    desc = "Solves most dynamic lighting artifacts caused by an issue with light environments and MSAA tiling."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x83777f4f # GTilingMode = 0
+        value = 0x00
+    [[patch.be32]]
+        address = 0x8256a998 # GUseTilingCode = FALSE, RHI
+        value = 0x39200000
+    [[patch.be32]]
+        address = 0x8256abb8 # GUseTilingCode = FALSE, FSceneRenderTargets
+        value = 0x39200000
+    [[patch.be32]]
+        address = 0x828324e4 # GMaxShadowDepthBufferSize = 2000, RHI
+        value = 0x396007d0
+    [[patch.be32]]
+        address = 0x82832704 # GMaxShadowDepthBufferSize = 2000, FSceneRenderTargets
+        value = 0x396007d0
 
 [[patch]]
     name = "RTV - Flickering Decals Fix"
@@ -33,15 +55,6 @@ title_id = "5451083B" # TQ-2107
         value = 0x39600000
 
 [[patch]]
-    name = "16x Anisotropic Filtering"
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x825c6c84
-        value = 0x38a00010
-
-[[patch]]
     name = "Disable Motion Blur"
     author = "boma"
     is_enabled = false
@@ -52,3 +65,12 @@ title_id = "5451083B" # TQ-2107
     [[patch.be32]]
         address = 0x82963f18
         value = 0x39600000
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825c6c84
+        value = 0x38a00010


### PR DESCRIPTION
The culprit behind the so-called "black shading" problem seems to be mostly caused by an issue Xenia has with UE3's tiled MSAA implementation. 

Forcing non-tiled MSAA eliminates all artifacts seen on characters and geometry within the boundaries of a light environment in Gears of War, Blacksite Area 51, Magnacarta 2, Mass Effect, and Unreal Tournament (2007).

For games that were made after SSAO was introduced to UDK, but before the Lightmass system was adopted that replaced lightmaps, the default int value of cvar `GMaxShadowDepthBufferSize` also needs to be increased (Gears of War 2, Dark Void).


This isn't necessarily a one size fits all approach. Mass Effect 2 and Mirror's Edge still exhibit the same significant shading issues with or w/o tiling. There are still a **_lot_** of additional games that need to be tested


Hopefully this is helpful beyond the realm of just patching.