### PR TITLE
Separate Color Adjustment patch for Sonic Unleashed

### DIFF
--- a/patches/53450812 - Sonic Unleashed (TU2).patch.toml
+++ b/patches/53450812 - Sonic Unleashed (TU2).patch.toml
@@ -22,6 +22,13 @@ hash = "98CA1A0A3A492388" # default.xex
     [[patch.be32]]
         address = 0x82baffa8
         value = 0x38800500
+
+[[patch]]
+    name = "Disable Color Adjustment"
+    desc = "Disables the yellowish color adjustment that's applied to the game screen."
+    author = "slashiee, ICUP321, boma"
+    is_enabled = false
+
     [[patch.be32]]
         address = 0x8328bb40
         value = 0x3f800000

--- a/patches/53450812 - Sonic Unleashed.patch.toml
+++ b/patches/53450812 - Sonic Unleashed.patch.toml
@@ -25,6 +25,13 @@ hash = "D26ABDDDED840999" # default.xex
     [[patch.be16]]
         address = 0x82ba902a
         value = 0x0500
+
+[[patch]]
+    name = "Disable Color Adjustment"
+    desc = "Disables the yellowish color adjustment that's applied to the game screen."
+    author = "slashiee, ICUP321"
+    is_enabled = false
+
     [[patch.be32]]
         address = 0x8327b450
         value = 0x3f800000


### PR DESCRIPTION
For some reason this patch was also a part of the `1280x720 Resolution` patch.

before:
![2022-08-20_17-10-52_xenia](https://user-images.githubusercontent.com/15317421/185770106-5e008f9c-a706-4c77-9048-c58d5002d5e1.png)

after:
![2022-08-20_17-11-05_xenia](https://user-images.githubusercontent.com/15317421/185770107-7b703ab8-9341-4e80-bc94-009b173bad58.png)
