### PR TITLE
Update 58410955 - Banjo-Tooie.patch.toml

### DIFF
--- a/patches/58410955 - Banjo-Tooie.patch.toml
+++ b/patches/58410955 - Banjo-Tooie.patch.toml
@@ -236,6 +236,22 @@ hash = "CFE7D4B66FAC7096" # default.xex
         value = 0x4bc6dffc
 
 [[patch]]
+    name = "Draw Distance Hack"
+    desc = "Uncapped actor spawn ranges and draw distances."
+    author = "retroben"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82240df8
+        value = 0x38606400
+    [[patch.be32]]
+        address = 0x8223f714
+        value = 0x60000000
+    [[patch.be32]]
+        address = 0x822a9f84
+        value = 0x60000000
+
+[[patch]]
     name = "Banjo Kazooie Fire Breath"
     desc = "Swaps normal idle attack with dragon Kazooie fire breath."
     author = "retroben"


### PR DESCRIPTION
I added a port of my recent Draw Distance Hack finding, it may have mild issues in WitchyWorld under extreme conditions such as using split-up and having Banjo stand on the diving board looking towards the world entrance with Kazooie in the same area and both Big Al's Burgers and Salty Joe's Fries activated.

A render freeze or some hitching can occur but no crashes or major glitches from that.
Later worlds not yet tested but hopefully they should fare better since WitchyWorld is nowhere near as bad as it acted on the N64 version of the code.