### PR TITLE
Add Breegull Bash cheat.

### DIFF
--- a/patches/58410955 - Banjo-Tooie.patch.toml
+++ b/patches/58410955 - Banjo-Tooie.patch.toml
@@ -309,6 +309,16 @@ hash = "CFE7D4B66FAC7096" # default.xex
         value = 0x60000000
 
 [[patch]]
+    name = "Access Breegull Bash"
+    desc = "Allows you to use Breegull Bash without actually having it."
+    author = "retroben"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820de0c8
+        value = 0x60000000
+
+[[patch]]
     name = "Banjo Kazooie Fire Breath"
     desc = "Swaps normal idle attack with dragon Kazooie fire breath."
     author = "retroben"


### PR DESCRIPTION
This allows you to use Breegull Bash without needing to do the cumbersome task of getting four SNS eggs in the first game before you can get the move in Tooie.

To note my experience with that task, I ran into trouble on Xenia before when trying to access the move with it not detecting the B-K eggs, yet Banjo N&B worked fine for detecting them being collected by revealing the special SNS Mumbo crates.