### PR TITLE
Max Parts Infinite Ammo Fuel Cheats for B-K N&B

### DIFF
--- a/patches/4D5307ED - Banjo-Kazooie Nuts & Bolts.patch.toml
+++ b/patches/4D5307ED - Banjo-Kazooie Nuts & Bolts.patch.toml
@@ -61,6 +61,24 @@ hash = "C03916823ADAC91B" # default.xex
         value = 0x60000000
 
 [[patch]]
+    name = "Fuel and Ammo Never Decrease"
+    author = "retroben"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822784e8
+        value = 0x60000000
+
+[[patch]]
+    name = "Max Acquired Parts Access"
+    author = "retroben"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8255ed1c
+        value = 0x392000ff
+
+[[patch]]
     name = "Screen Always Bright"
     author = "Serenity"
     is_enabled = false

--- a/patches/58410955 - Banjo-Tooie.patch.toml
+++ b/patches/58410955 - Banjo-Tooie.patch.toml
@@ -309,6 +309,16 @@ hash = "CFE7D4B66FAC7096" # default.xex
         value = 0x60000000
 
 [[patch]]
+    name = "Access Breegull Bash"
+    desc = "Allows you to use Breegull Bash without actually having it."
+    author = "retroben"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820de0c8
+        value = 0x60000000
+
+[[patch]]
     name = "Banjo Kazooie Fire Breath"
     desc = "Swaps normal idle attack with dragon Kazooie fire breath."
     author = "retroben"


### PR DESCRIPTION
(I had accidentally sent my own fork a pull request before this, hate when that happens...)

Max parts doesn't modify the actual owned parts count but it allows uncapped parts usage even after saving vehicles as long as the code is active. Want six Super Engines on a vehicle after getting one? No problem! (19 jets can be fun as well)

Ammo and Fuel Never Decrease cheat should be self-explanatory, allowing only needing smallest/lightest fuel and ammo for more broken vehicle building. Attempting to attach two ejector seat parts hangs the game, self destruct likely may also cause hanging with trying to add two or more.
![Jets and Jets](https://user-images.githubusercontent.com/16418716/211361802-559a4220-0230-495e-b6e3-0b3ee0b7870e.PNG)
