### PR TITLE
More Fable 2 GoTY Patches

### DIFF
--- a/patches/4D5307F1 - Fable II (GOTY_Platinum Edition).patch.toml
+++ b/patches/4D5307F1 - Fable II (GOTY_Platinum Edition).patch.toml
@@ -35,3 +35,51 @@ hash = "4145F96D2DEE2AB5" # default.xex
     [[patch.be8]]
         address = 0x8238df3f
         value = 0x01
+
+[[patch]]
+    name = "Disable Texture Morphing"
+    desc = "Prevents the dog & hero's broken textures. Makeup is still bugged. Makes the evil morph strange."
+    author = "Guy"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x8220EF10
+        value = 0x4280
+
+[[patch]]
+    name = "High Tick Rate"
+    desc = "Sets engine tick rate to 30hz, from 15. Makes a smoother expression meter and UI. Causes small side effects."
+    author = "Guy"
+    is_enabled = false
+
+    [[patch.be32]]
+       address = 0x8233aeb4
+       value = 0x60000000
+
+    [[patch.be8]]
+        address = 0x83319511
+        value = 0x3E
+
+[[patch]]
+    name = "Unlock Website Items"
+    desc = "Unlocks the Guild Chest containing the items that were obtainable from the Fable 2 website."
+    author = "Guy"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8256e4e3
+        value = 0x01
+    
+    [[patch.be32]]
+        address = 0x8256e4b8
+        value = 0x42800028
+
+[[patch]]
+    name = "Unlock Collectors Edition Content"
+    desc = "Adds Hal's items to the guild chest, and enables the Hall of the Dead dungeon."
+    author = "Guy"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824B366C
+        value = 0x39200001

--- a/patches/4D5307F1 - Fable II (GOTY_Platinum Edition).patch.toml
+++ b/patches/4D5307F1 - Fable II (GOTY_Platinum Edition).patch.toml
@@ -55,7 +55,6 @@ hash = "4145F96D2DEE2AB5" # default.xex
     [[patch.be32]]
        address = 0x8233aeb4
        value = 0x60000000
-
     [[patch.be8]]
         address = 0x83319511
         value = 0x3E
@@ -69,7 +68,6 @@ hash = "4145F96D2DEE2AB5" # default.xex
     [[patch.be8]]
         address = 0x8256e4e3
         value = 0x01
-    
     [[patch.be32]]
         address = 0x8256e4b8
         value = 0x42800028


### PR DESCRIPTION
Four new patches for v10.1

### Disable Texture Morphing
Disables texture morph generation, preventing the black texture bug that the hero and dog suffer from.
The patch makes the evil morph look strange with flesh coloured horns, and it disables will lines.

### High Tick Rate
Makes the engine update 30 times per second rather than 15. The expression meter movement becomes *much* smoother which makes jobs much more enjoyable to play. Certain other UI elements also become smoother.

Other things are effected in small ways, for better or for worse. Swimming speed is increased. It can be a little tricky to ascend certain stairs and go over some bumps. Some 2d animations like the breadcrumb trail are sped up slightly.

### Unlock Website Items
Lets you collect the unobtainable website items from the Guild Hall chest, like the chicken suit.

### Unlock Collectors Edition Content
Lets you collect the Halo suit + energy sword from the Guild Hall chest, and unlocks the Hall of the Dead dungeon.