### PR TITLE
Update 4D5307DF - ブルードラゴン.patch.toml

### DIFF
--- a/patches/4D5307DF - ブルードラゴン.patch.toml
+++ b/patches/4D5307DF - ブルードラゴン.patch.toml
@@ -12,3 +12,13 @@ hash = "8149463D9BEE5FD0" # default.xex
     [[patch.be8]]
         address = 0x820cd577
         value = 0xff
+
+[[patch]]
+    name = "Enable Debug Draw"
+    author = "Wylie"
+    desc = "Adds Debug information into the Game World" # WireFrames, Event Information, etc... Note: Outdoor areas are buggy
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x820CD75F
+        value = 0xff

--- a/patches/4D5307DF - ブルードラゴン.patch.toml
+++ b/patches/4D5307DF - ブルードラゴン.patch.toml
@@ -20,5 +20,5 @@ hash = "8149463D9BEE5FD0" # default.xex
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x820CD75F
+        address = 0x820cd75f
         value = 0xff


### PR DESCRIPTION
Adds Extra debug information to the game world such as event information and wireframe (can't be enabled using debug menu so patch is needed)

![image](https://user-images.githubusercontent.com/62946885/217617194-8b01d144-8887-44d8-a764-6777c746e465.png)
