### PR TITLE
Update 4D5307DF - Blue Dragon.patch.toml

### DIFF
--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -58,15 +58,15 @@ hash = "3C19B6F951F93D49" # Disc 1/2/3, default.xex
     is_enabled = false
 
     [[patch.be32]] # Labels
-        address = 0x820ce708 
+        address = 0x820ce708
         value = 0x39600001
 
     [[patch.be32]] # Debug Content Start
-        address = 0x820ce808 
+        address = 0x820ce808
         value = 0x396000ff
 
     [[patch.be32]] # Debug Content End
-        address = 0x820ce818 
+        address = 0x820ce818
         value = 0x39600000
 
     [[patch.be32]] # Debug Menu

--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -72,8 +72,12 @@ hash = "3C19B6F951F93D49" # Disc 1/2/3, default.xex
   [[patch.be32]] # Debug Menu
     address = 0x820C0F80
     value = 0x60000000
+    
+  [[patch.be32]] # Main Content part 1
+    address = 0x820C1074
+    value = 0x60000000
 
-  [[patch.be32]] # Main Content
+  [[patch.be32]] # Main Content part 2
     address = 0x820C1094
     value = 0x60000000
 

--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -72,7 +72,7 @@ hash = "3C19B6F951F93D49" # Disc 1/2/3, default.xex
     [[patch.be32]] # Debug Menu
         address = 0x820c0f80
         value = 0x60000000
-    
+
     [[patch.be32]] # Main Content part 1
         address = 0x820c1074
         value = 0x60000000

--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -58,27 +58,27 @@ hash = "3C19B6F951F93D49" # Disc 1/2/3, default.xex
     is_enabled = false
 
     [[patch.be32]] # Labels
-        address = 0x820CE708 
+        address = 0x820ce708 
         value = 0x39600001
 
     [[patch.be32]] # Debug Content Start
-        address = 0x820CE808 
+        address = 0x820ce808 
         value = 0x396000ff
 
     [[patch.be32]] # Debug Content End
-        address = 0x820CE818 
+        address = 0x820ce818 
         value = 0x39600000
 
     [[patch.be32]] # Debug Menu
-        address = 0x820C0F80
+        address = 0x820c0f80
         value = 0x60000000
     
     [[patch.be32]] # Main Content part 1
-        address = 0x820C1074
+        address = 0x820c1074
         value = 0x60000000
 
     [[patch.be32]] # Main Content part 2
-        address = 0x820C1094
+        address = 0x820c1094
         value = 0x60000000
 
     [[patch.be8]] # Add tools

--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -52,35 +52,35 @@ hash = "3C19B6F951F93D49" # Disc 1/2/3, default.xex
         value = 0x39400001
 
 [[patch]]
-  name = "Debug Menu"
-  author = "Wylie"
-  desc = "Enables Debug Menu with wireframes and labels"
-  is_enabled = false
+    name = "Debug Menu"
+    author = "Wylie"
+    desc = "Enables Debug Menu with wireframes and labels"
+    is_enabled = false
 
-  [[patch.be32]] # Labels
-    address = 0x820CE708 
-    value = 0x39600001
+    [[patch.be32]] # Labels
+        address = 0x820CE708 
+        value = 0x39600001
 
-  [[patch.be32]] # Debug Content Start
-    address = 0x820CE808 
-    value = 0x396000ff
+    [[patch.be32]] # Debug Content Start
+        address = 0x820CE808 
+        value = 0x396000ff
 
-  [[patch.be32]] # Debug Content End
-    address = 0x820CE818 
-    value = 0x39600000
+    [[patch.be32]] # Debug Content End
+        address = 0x820CE818 
+        value = 0x39600000
 
-  [[patch.be32]] # Debug Menu
-    address = 0x820C0F80
-    value = 0x60000000
+    [[patch.be32]] # Debug Menu
+        address = 0x820C0F80
+        value = 0x60000000
     
-  [[patch.be32]] # Main Content part 1
-    address = 0x820C1074
-    value = 0x60000000
+    [[patch.be32]] # Main Content part 1
+        address = 0x820C1074
+        value = 0x60000000
 
-  [[patch.be32]] # Main Content part 2
-    address = 0x820C1094
-    value = 0x60000000
+    [[patch.be32]] # Main Content part 2
+        address = 0x820C1094
+        value = 0x60000000
 
-  [[patch.be8]] # Add tools
-    address = 0x820ce7cb
-    value = 0xff
+    [[patch.be8]] # Add tools
+        address = 0x820ce7cb
+        value = 0xff

--- a/patches/4D5307DF - Blue Dragon.patch.toml
+++ b/patches/4D5307DF - Blue Dragon.patch.toml
@@ -50,3 +50,33 @@ hash = "3C19B6F951F93D49" # Disc 1/2/3, default.xex
     [[patch.be32]]
         address = 0x8246ab68 # Vsync flip rate
         value = 0x39400001
+
+[[patch]]
+  name = "Debug Menu"
+  author = "Wylie"
+  desc = "Enables Debug Menu with wireframes and labels"
+  is_enabled = false
+
+  [[patch.be32]] # Labels
+    address = 0x820CE708 
+    value = 0x39600001
+
+  [[patch.be32]] # Debug Content Start
+    address = 0x820CE808 
+    value = 0x396000ff
+
+  [[patch.be32]] # Debug Content End
+    address = 0x820CE818 
+    value = 0x39600000
+
+  [[patch.be32]] # Debug Menu
+    address = 0x820C0F80
+    value = 0x60000000
+
+  [[patch.be32]] # Main Content
+    address = 0x820C1094
+    value = 0x60000000
+
+  [[patch.be8]] # Add tools
+    address = 0x820ce7cb
+    value = 0xff


### PR DESCRIPTION
Debug Menu figured out on english releases. Credits to [Drago](https://github.com/megadrago88) for helping
![image](https://user-images.githubusercontent.com/62946885/218337606-7fa143ce-a42d-4058-8704-fbb26849beda.png)

Features of this debug menu are a bit unstable but the folks at the [blue dragon speedrunning discord server](https://discord.gg/gqpBMVh9xP) are working on stablising these features
