### PR TITLE
Add TU patches for Kameo, PDZ and Viva Piñata

### DIFF
--- a/patches/4D5307D2 - Kameo Elements of Power (TU2).patch.toml
+++ b/patches/4D5307D2 - Kameo Elements of Power (TU2).patch.toml
@@ -15,7 +15,7 @@ hash = "B94D3AB68548DF97" # default.xex
     name = "Aspect Ratio"
     desc = "See note about aspect ratio patches in the README."
     author = "Margen67, ICUP321"
-    is_enabled = true
+    is_enabled = false
 
     [[patch.be32]]
         address = 0x82089cec

--- a/patches/4D5307D2 - Kameo Elements of Power (TU2).patch.toml
+++ b/patches/4D5307D2 - Kameo Elements of Power (TU2).patch.toml
@@ -1,0 +1,22 @@
+title_name = "Kameo: Elements of Power (TU2)"
+title_id = "4D5307D2" # MS-2002
+hash = "B94D3AB68548DF97" # default.xex
+#media_id = "45BB5521" # Disc (Europe): redump.org/disc/8561
+
+[[patch]]
+    name = "60 FPS"
+    author = "Margen67, ICUP321"
+    is_enabled = false
+    [[patch.be8]]
+        address = 0x820d17c7
+        value = 0x01
+
+[[patch]]
+    name = "Aspect Ratio"
+    desc = "See note about aspect ratio patches in the README."
+    author = "Margen67, ICUP321"
+    is_enabled = true
+
+    [[patch.be32]]
+        address = 0x82089cec
+        value = 0x4018e38e

--- a/patches/4D5307D3 - Perfect Dark Zero (Platinum Hits).patch.toml
+++ b/patches/4D5307D3 - Perfect Dark Zero (Platinum Hits).patch.toml
@@ -1,7 +1,7 @@
-title_name = "Perfect Dark: Zero"
+title_name = "Perfect Dark: Zero (Platinum Hits)"
 title_id = "4D5307D3" # MS-2003
-hash = "C1572363239DB6CE" # default.xex
-#media_id = "41EEAFCB" # Disc (USA): http://redump.org/disc/11810
+hash = "C234707B99D5E62F" # default.xex
+#media_id = "40C97944" # Disc (USA): http://redump.org/disc/72218/
 
 [[patch]]
     name = "60 FPS"
@@ -10,27 +10,27 @@ hash = "C1572363239DB6CE" # default.xex
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x826cfb77
+        address = 0x826df8f7
         value = 0x01
 
 [[patch]]
     name = "Aspect Ratio"
     desc = "See note about aspect ratio patches in the README."
-    author = "Margen67"
+    author = "Margen67, ICUP321"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x820ec158
+        address = 0x820eae50
         value = 0x4018e38e
 
 [[patch]] # TODO(illusion): Need to test with picked up weapons.
     name = "Bottomless Clip"
-    author = "illusion"
+    author = "illusion, ICUP321"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825744a8
+        address = 0x82583d68
         value = 0x4e800020
     [[patch.be16]]
-        address = 0x8220d138
+        address = 0x822143b8
         value = 0x4800

--- a/patches/4D5307D3 - Perfect Dark Zero (TU3).patch.toml
+++ b/patches/4D5307D3 - Perfect Dark Zero (TU3).patch.toml
@@ -1,6 +1,6 @@
-title_name = "Perfect Dark: Zero"
+title_name = "Perfect Dark: Zero (TU3)"
 title_id = "4D5307D3" # MS-2003
-hash = "C1572363239DB6CE" # default.xex
+hash = "0B7B4240C8EDD54C" # default.xex
 #media_id = "41EEAFCB" # Disc (USA): http://redump.org/disc/11810
 
 [[patch]]
@@ -10,27 +10,27 @@ hash = "C1572363239DB6CE" # default.xex
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x826cfb77
+        address = 0x826df8c7
         value = 0x01
 
 [[patch]]
     name = "Aspect Ratio"
     desc = "See note about aspect ratio patches in the README."
-    author = "Margen67"
+    author = "Margen67, ICUP321"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x820ec158
+        address = 0x820eae70
         value = 0x4018e38e
 
 [[patch]] # TODO(illusion): Need to test with picked up weapons.
     name = "Bottomless Clip"
-    author = "illusion"
+    author = "illusion, ICUP321"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825744a8
+        address = 0x82583d38
         value = 0x4e800020
     [[patch.be16]]
-        address = 0x8220d138
+        address = 0x822143b8
         value = 0x4800

--- a/patches/4D53085F - Viva Piñata Trouble in Paradise (TU1).patch.toml
+++ b/patches/4D53085F - Viva Piñata Trouble in Paradise (TU1).patch.toml
@@ -1,0 +1,13 @@
+title_name = "Viva Piñata: Trouble in Paradise (TU1)" # Pinata TIP
+title_id = "4D53085F" # MS-2143
+hash = "69A34EC1CCA0649D" # default.xex
+#media_id = "76A44A5D" # Disc (US, Australia): http://redump.org/disc/67404
+
+[[patch]]
+    name = "60 FPS"
+    author = "Margen67, ICUP321"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8229b7ef
+        value = 0x01


### PR DESCRIPTION
Adds codes for games with title updates like Kameo, Perfect Dark Zero, and Viva Piñata: Trouble in Paradise. The FPS patch for Perfect Dark Zero was also broken, but I fixed it and changed it to allow the game to run up to 60 FPS to be more in-line with other Rare games. (Besides, if anyone wanted to play at higher than 60 FPS, they could just disable VSync in settings).