### PR TITLE
Fix broken shadows in Turning Point: Fall of Liberty

### DIFF
--- a/patches/434D07E0 - Turning Point Fall of Liberty.patch.toml
+++ b/patches/434D07E0 - Turning Point Fall of Liberty.patch.toml
@@ -5,7 +5,7 @@ hash = "1F88F0617288EB51" # default.xex
 
 [[patch]]
     name = "Black Shading Fix"
-    desc = "Disables MSAA"
+    desc = "Disables MSAA."
     author = "Omegasis"
     is_enabled = false
 

--- a/patches/434D07E0 - Turning Point Fall of Liberty.patch.toml
+++ b/patches/434D07E0 - Turning Point Fall of Liberty.patch.toml
@@ -1,0 +1,14 @@
+title_name = "Turning Point: Fall of Liberty"
+title_id = "434D07E0" # CM-2016
+hash = "1F88F0617288EB51" # default.xex
+#media_id = "4477F0D6" # Disc (USA, Europe): http://redump.org/disc/14546
+
+[[patch]]
+    name = "Black Shading Fix"
+    desc = "Disables MSAA"
+    author = "Omegasis"
+    is_enabled = false
+
+    [[patch.be8]] # tilingcode
+        address = 0x82e2bd6b
+        value = 0x04


### PR DESCRIPTION
This patch fixes the broken shadows in the game.