### PR TITLE
added invisible vehicles & weapons

### DIFF
--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -72,11 +72,11 @@ hash = "2537D5F11410BE0A" # default.xex
     author = "godzhand"
     is_enabled = false
     [[patch.be32]]
-        address = 0x821A5F64
-        value = 0x38A000ff
+        address = 0x821a5F64
+        value = 0x38a000ff
     [[patch.be32]]
-        address = 0x821A5F68
+        address = 0x821a5F68
         value = 0x38800000
     [[patch.be32]]
-        address = 0x821A5F6c
+        address = 0x821a5F6c
         value = 0x38600000

--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -65,3 +65,18 @@ hash = "2537D5F11410BE0A" # default.xex
     [[patch.be8]]
         address = 0x835f4c3e
         value = 0x01
+
+[[patch]]
+    name = "invisible objects"
+    desc = "all objects such as weapons and vehicles do not load in until you exit territory"
+    author = "godzhand"
+    is_enabled = false
+    [[patch.be32]]
+        address = 0x821A5F64
+        value = 0x38A000ff
+    [[patch.be32]]
+        address = 0x821A5F68
+        value = 0x38800000
+    [[patch.be32]]
+        address = 0x821A5F6c
+        value = 0x38600000


### PR DESCRIPTION
when enabled, new games or saves will load in without vehicles or weapons  making them invisible,  leave the territory to load them back in.