### PR TITLE
Saints Row: Debug patches

### DIFF
--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -128,8 +128,8 @@ hash = [
 
 [[patch]]
     name = "Enable Debug Console"
-    desc = "Requires keyboard_passthru to be changed from false to true in the Xenia Canary config; Requires Xenia Canary version 271befc from January 25th or older."
-    author = "emoose"
+    desc = "Requires keyboard_mode to be changed from 0 to 2 in the Xenia Canary config, press ~ to open and close the console."
+    author = "emoose, expanded by Clippy95"
     is_enabled = false
 
     [[patch.be32]]
@@ -141,9 +141,36 @@ hash = [
     [[patch.be32]]
         address = 0x82660268
         value = 0x480b8e14
-    [[patch.be8]]
-        address = 0x835f4c3e
-        value = 0x01
+    [[patch.be32]]
+        address = 0x8263e334
+        value = 0x4bb693b0 # b 821a76e4
+    [[patch.be32]]
+        address = 0x821a76e4
+        value = 0x8b1e000b # lbz r24,0xb(r30)
+    [[patch.be32]]
+        address = 0x821a76e8
+        value = 0x6b180001 # xori r24,r24,0x1 # originally set to 0 to close the console window, now just xor to open/close.
+    [[patch.be32]]
+        address = 0x821a76ec
+        value = 0x9b1e000b # stb r24,0xb(r30)
+    [[patch.be32]]
+        address = 0x821a76f0
+        value = 0x48496c48 # b 0x8263e338
+    [[patch.be32]]
+        address = 0x82198b58
+        value = 0x60000000
+    [[patch.be32]]
+        address = 0x82198b5c
+        value = 0x60000000
+    [[patch.be32]]
+        address = 0x82198b5c
+        value = 0x42800008
+    [[patch.be32]]
+        address = 0x8263d150
+        value = 0x60000000
+    [[patch.be32]]
+        address = 0x8263d228
+        value = 0x8263e330 # Allow to open/close console with ~ key
 
 [[patch]]
     name = "Loose VPP Content loading" # loose->dlcs->vpps

--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -365,3 +365,13 @@ hash = [
     [[patch.f32]]
         address = 0x8208c88c
         value = -0.5
+
+[[patch]]
+    name = "LUA debug_print to log"
+    desc = "Prints mostly unused debug_print to Xenia's log, mostly useful in mod making."
+    author = "Clippy95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824f1164
+        value = 0x482ae6f9 # bl DbgPrint

--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -289,34 +289,34 @@ hash = [
         value = 0x39000500
     [[patch.be32]]
         address = 0x821952f8
-        value = 0x3920021c
+        value = 0x39200224
     [[patch.be32]]
         address = 0x8219360c
         value = 0x60000000
     [[patch.be16]]
         address = 0x827f70ba
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827f70ca
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827f70da
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827f70ea
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827adb76
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827f6f82
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827f701e
-        value = 0x021c
+        value = 0x0224
     [[patch.be16]]
         address = 0x827f702e
-        value = 0x021c
+        value = 0x0224
     [[patch.f32]]
         address = 0x8208b94c # General FOV Multiplier
         value = 1.777741190

--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -160,17 +160,17 @@ hash = [
         address = 0x82198b58
         value = 0x60000000
     [[patch.be32]]
-        address = 0x82198b5c
+        address = 0x82198b60
         value = 0x60000000
-    [[patch.be32]]
-        address = 0x82198b5c
-        value = 0x42800008
     [[patch.be32]]
         address = 0x8263d150
         value = 0x60000000
     [[patch.be32]]
         address = 0x8263d228
         value = 0x8263e330 # Allow to open/close console with ~ key
+    [[patch.be32]]
+        address = 0x8263d188
+        value = 0x8263e224 # Stop ESC from closing/opening console.
 
 [[patch]]
     name = "Loose VPP Content loading" # loose->dlcs->vpps

--- a/patches/545107D1 - Saints Row (TU1).patch.toml
+++ b/patches/545107D1 - Saints Row (TU1).patch.toml
@@ -318,7 +318,7 @@ hash = [
         address = 0x827f702e
         value = 0x021c
     [[patch.f32]]
-        address = 0x8208b94b # General FOV Multiplier
+        address = 0x8208b94c # General FOV Multiplier
         value = 1.777741190
     [[patch.f32]]
         address = 0x8208c818 # Cutscene FOV Multiplier.

--- a/patches/545107D1 - Saints Row.patch.toml
+++ b/patches/545107D1 - Saints Row.patch.toml
@@ -48,7 +48,7 @@ hash = "437A5F51A72C9C6A" # default.xex
 
 [[patch]]
     name = "Enable Debug Console"
-    desc = "Requires keyboard_passthru to be changed from false to true in the Xenia Canary config; Requires Xenia Canary version 271befc from January 25th or older."
+    desc = "Requires keyboard_mode to be changed from 0 to 2 in the Xenia Canary config"
     author = "emoose, Tervel"
     is_enabled = false
 


### PR DESCRIPTION
For Saints Row TU1:

- Edits current emoose's debug console patch to allow you to open / close the console window instead of only closing.
- Print debug_print LUA function to Xenia console / log with DbgPrint