### PR TITLE
feat: add 41560817 MW2 patches for upscale flicker fix

### DIFF
--- a/patches/41560817 - Call of Duty - Modern Warfare 2 (TU0).patch.toml
+++ b/patches/41560817 - Call of Duty - Modern Warfare 2 (TU0).patch.toml
@@ -1,0 +1,27 @@
+title_name = "Call of Duty: Modern Warfare 2"
+title_id = "41560817" # AV-2071
+hash = "A19F21C38721F84F" # default.xex
+#media_id = "2C8C0267" # Disc (USA, Europe): http://redump.org/disc/11809
+
+[[patch]]
+    name = "Native 1280x720 resolution"
+    desc = "Reduces flickering on upscaled resolutions x2 and x3"
+    author = "mo"
+    is_enabled = false
+
+    # R_SetWndParms
+
+    # wndParms->sceneWidth
+    [[patch.be16]]
+        address = 0x8238e61e
+        value = 0x0500       # 1024 -> 1280
+
+    # wndParms->sceneHeight
+    [[patch.be16]]
+        address = 0x8238e622
+        value = 0x02d0       # 600 -> 720
+
+    # wndParms->aaSamples
+    [[patch.be16]]
+        address = 0x8238e636
+        value = 0x0000       # 2 -> 0

--- a/patches/41560817 - Call of Duty - Modern Warfare 2 (TU9).patch.toml
+++ b/patches/41560817 - Call of Duty - Modern Warfare 2 (TU9).patch.toml
@@ -1,0 +1,27 @@
+title_name = "Call of Duty: Modern Warfare 2"
+title_id = "41560817" # AV-2071
+hash = "0BF957FE8ABE4B7C" # default.xex
+#media_id = "2C8C0267" # Disc (USA, Europe): http://redump.org/disc/11809
+
+[[patch]]
+    name = "Native 1280x720 resolution"
+    desc = "Reduces flickering on upscaled resolutions x2 and x3"
+    author = "mo"
+    is_enabled = false
+
+    # R_SetWndParms
+
+    # wndParms->sceneWidth
+    [[patch.be16]]
+        address = 0x8238e68e
+        value = 0x0500       # 1024 -> 1280
+
+    # wndParms->sceneHeight
+    [[patch.be16]]
+        address = 0x8238e692
+        value = 0x02d0       # 600 -> 720
+
+    # wndParms->aaSamples
+    [[patch.be16]]
+        address = 0x8238e6a6
+        value = 0x0000       # 2 -> 0

--- a/patches/41560817 - Call of Duty - Modern Warfare 2 MP (TU0).patch.toml
+++ b/patches/41560817 - Call of Duty - Modern Warfare 2 MP (TU0).patch.toml
@@ -1,0 +1,27 @@
+title_name = "Call of Duty: Modern Warfare 2"
+title_id = "41560817" # AV-2071
+hash = "57581F341CEC2F16" # default_mp.xex
+#media_id = "2C8C0267" # Disc (USA, Europe): http://redump.org/disc/11809
+
+[[patch]]
+    name = "Native 1280x720 resolution"
+    desc = "Reduces flickering on upscaled resolutions x2 and x3"
+    author = "mo"
+    is_enabled = false
+
+    # R_SetWndParms
+
+    # wndParms->sceneWidth
+    [[patch.be16]]
+        address = 0x823c2d3e
+        value = 0x0500       # 1024 -> 1280
+
+    # wndParms->sceneHeight
+    [[patch.be16]]
+        address = 0x823c2d42
+        value = 0x02d0       # 600 -> 720
+
+    # wndParms->aaSamples
+    [[patch.be16]]
+        address = 0x823c2d56
+        value = 0x0000       # 2 -> 0

--- a/patches/41560817 - Call of Duty - Modern Warfare 2 MP (TU9).patch.toml
+++ b/patches/41560817 - Call of Duty - Modern Warfare 2 MP (TU9).patch.toml
@@ -1,0 +1,27 @@
+title_name = "Call of Duty: Modern Warfare 2"
+title_id = "41560817" # AV-2071
+hash = "766CC31C6293CB73" # default_mp.xex
+#media_id = "2C8C0267" # Disc (USA, Europe): http://redump.org/disc/11809
+
+[[patch]]
+    name = "Native 1280x720 resolution"
+    desc = "Reduces flickering on upscaled resolutions x2 and x3"
+    author = "mo"
+    is_enabled = false
+
+    # R_SetWndParms
+
+    # wndParms->sceneWidth
+    [[patch.be16]]
+        address = 0x8234c6a6
+        value = 0x0500       # 1024 -> 1280
+
+    # wndParms->sceneHeight
+    [[patch.be16]]
+        address = 0x8234c6aa
+        value = 0x02d0       # 600 -> 720
+
+    # wndParms->aaSamples
+    [[patch.be16]]
+        address = 0x8234c6be
+        value = 0x0000       # 2 -> 0


### PR DESCRIPTION
I have no idea why this works but it makes the game at least playable when using upscaling x2 or x3.

Before: **WARNING FLASHING VIDEO**


https://github.com/user-attachments/assets/9148ac0a-b488-4a42-acc0-387aa333e38d

After:


https://github.com/user-attachments/assets/0f86dfc3-d450-4ba3-8ac2-42db2a22517f

