### PR TITLE
Update Banjo patches

### DIFF
--- a/patches/4D5307ED - Banjo-Kazooie Nuts & Bolts (TU3).patch.toml
+++ b/patches/4D5307ED - Banjo-Kazooie Nuts & Bolts (TU3).patch.toml
@@ -49,6 +49,15 @@ hash = "13D07541617C6257" # default.xex
         value = 0x4800
 
 [[patch]]
+    name = "Disable LoD"
+    author = "retroben, ICUP321"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82bc40b0
+        value = 0x48000018
+
+[[patch]]
     name = "Notes Never Decrease"
     author = "Etokapa, Serenity, ICUP321"
     is_enabled = false
@@ -72,8 +81,35 @@ hash = "13D07541617C6257" # default.xex
     is_enabled = false
 
     [[patch.be32]]
+        address = 0x824facf8
+        value = 0x38e000ff
+    [[patch.be32]]
+        address = 0x824fb6f4
+        value = 0x394000ff
+    [[patch.be32]]
         address = 0x825425c4
         value = 0x392000ff
+
+[[patch]]
+    name = "Extended Build Range"
+    author = "retroben, ICUP321"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x826333ec
+        value = 0x2f09001f
+    [[patch.be32]]
+        address = 0x82633408
+        value = 0x2f09001f
+    [[patch.be32]]
+        address = 0x82633424
+        value = 0x2f0b001f
+    [[patch.be32]]
+        address = 0x82633510
+        value = 0x21290020
+    [[patch.be32]]
+        address = 0x82633580
+        value = 0x216b0020
 
 [[patch]]
     name = "Screen Always Bright"

--- a/patches/58410954 - Banjo-Kazooie (TU2).patch.toml
+++ b/patches/58410954 - Banjo-Kazooie (TU2).patch.toml
@@ -1,0 +1,14 @@
+title_name = "Banjo-Kazooie (TU2)"
+title_id = "58410954" # XA-2388
+hash = "CAFD5CE4E98048D9" # default.xex
+#media_id = "69C685B7"
+
+[[patch]]
+    name = "Always HD Banjo"
+    desc = "Devs neglected to change the outdoors model ID."
+    author = "retroben"
+    is_enabled = false
+
+    [[patch.be16]]
+        address = 0x8209d24e
+        value = 0x034e


### PR DESCRIPTION
Ports over the newly-added patches for Banjo-Kazooie Nuts & Bolts by retroben to TU3.

I also added a template for Title Update 2 of Banjo-Kazooie with one code that already works, but I will NOT be porting the 60 FPS patch to TU2 since it uses ASM injection.