### PR TITLE
Some patches

### DIFF
--- a/patches/415607EF - Singularity (TU2).patch.toml
+++ b/patches/415607EF - Singularity (TU2).patch.toml
@@ -23,7 +23,7 @@ hash = "E3D3817546C9A20F" # default.xex
 
     [[patch.be32]]
         address = 0x82dbbdd4
-        value = 0x38a00000
+        value = 0x38a00010
 
 [[patch]]
     name = "Disable Coalesced hash check"
@@ -31,6 +31,6 @@ hash = "E3D3817546C9A20F" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83a02e84
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x829fc6c7
+        value = 0x00

--- a/patches/415607EF - Singularity.patch.toml
+++ b/patches/415607EF - Singularity.patch.toml
@@ -31,6 +31,6 @@ hash = "AFB45E9586F98A97" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83a02e84
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x829fc4d7
+        value = 0x00

--- a/patches/4156084C - Transformers War for Cybertron (TU1).patch.toml
+++ b/patches/4156084C - Transformers War for Cybertron (TU1).patch.toml
@@ -1,4 +1,4 @@
-title_name = "Transformers War for Cybertron" # v4.0.1
+title_name = "Transformers War for Cybertron" # TU1
 title_id = "4156084C" # AV-2124
 hash = "3AF46199AE02D5C7" # default.xex
 #media_id = [
@@ -53,6 +53,6 @@ hash = "3AF46199AE02D5C7" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83910000
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x833170ff
+        value = 0x00

--- a/patches/4156084C - Transformers War for Cybertron.patch.toml
+++ b/patches/4156084C - Transformers War for Cybertron.patch.toml
@@ -53,6 +53,6 @@ hash = "0D6CA1E3F19F0087" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83900000
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x83304daf
+        value = 0x00

--- a/patches/4156088B - Apache Air Assault (TU1).patch.toml
+++ b/patches/4156088B - Apache Air Assault (TU1).patch.toml
@@ -1,0 +1,26 @@
+title_name = "Apache: Air Assault" # TU1
+title_id = "4156088B" # AV-2187
+hash = "0A0A010AD6160E10" # default.xex
+#media_id = "089FC7A8" # Disc (USA): http://redump.org/disc/51087
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "Doesn't matter if Xenia vsync is enabled or not."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82589cf0
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82589cff
+        value = 0x00 # 0x00=unlimited; 0x01=60FPS
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8228d8af
+        value = 0x00

--- a/patches/4156088B - Apache Air Assault.patch.toml
+++ b/patches/4156088B - Apache Air Assault.patch.toml
@@ -1,0 +1,26 @@
+title_name = "Apache: Air Assault"
+title_id = "4156088B" # AV-2187
+hash = "FF58690C63F21B40" # default.xex
+#media_id = "089FC7A8" # Disc (USA): http://redump.org/disc/51087
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "Doesn't matter if Xenia vsync is enabled or not."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82589b98
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82589ba7
+        value = 0x00 # 0x00=unlimited; 0x01=60FPS
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8228d7cf
+        value = 0x00

--- a/patches/415608A4 - Transformers Dark of the Moon (TU1).patch.toml
+++ b/patches/415608A4 - Transformers Dark of the Moon (TU1).patch.toml
@@ -1,4 +1,4 @@
-title_name = "Transformers: Dark of the Moon" # v2.0.1
+title_name = "Transformers: Dark of the Moon" # TU1
 title_id = "415608A4" # AV-2212
 hash = "F408C5D3F843BA68" # default.xex
 #media_id = "262F2D45" # Disc (USA): http://redump.org/disc/41956
@@ -31,6 +31,6 @@ hash = "F408C5D3F843BA68" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83a90000
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x8351f7af
+        value = 0x00

--- a/patches/415608A4 - Transformers Dark of the Moon.patch.toml
+++ b/patches/415608A4 - Transformers Dark of the Moon.patch.toml
@@ -31,6 +31,6 @@ hash = "AEC574493A626D6A" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83a90000
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x8351e05f
+        value = 0x00

--- a/patches/425307D7 - Hunted The Demon's Forge (TU1).patch.toml
+++ b/patches/425307D7 - Hunted The Demon's Forge (TU1).patch.toml
@@ -1,4 +1,4 @@
-title_name = "Hunted: The Demon's Forge" # v2.0.1
+title_name = "Hunted: The Demon's Forge" # TU1
 title_id = "425307D7" # BS-2007
 hash = "7FCEB2E89622CD7B" # default.xex
 #media_id = "7084F7FD" # Disc (USA): http://redump.org/disc/100843
@@ -15,3 +15,24 @@ hash = "7FCEB2E89622CD7B" # default.xex
     [[patch.be8]]
         address = 0x82d1676f
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82a37d54
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8398cb78
+        value = 0x01
+    [[patch.be8]]
+        address = 0x8398cb88 # Frametime
+        value = 0x01

--- a/patches/425307E3 - Dishonored (Europe).patch.toml
+++ b/patches/425307E3 - Dishonored (Europe).patch.toml
@@ -1,0 +1,50 @@
+title_name = "Dishonored"
+title_id = "425307E3" # BS-2019
+hash = "FDFA2324099CE50E" # default.xex
+#media_id = [
+#    "76D06EBB", # Disc (Europe): http://redump.org/disc/36105
+#    "4FEBCE15"  # Disc (Europe): http://redump.org/disc/72633
+#]
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8242d308
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82a4e9bb
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8274a10c
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x834114a8
+        value = 0x01
+    [[patch.be8]]
+        address = 0x834114b4 # Frametime
+        value = 0x01
+
+[[patch]]
+    name = "Show FPS Graph"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x834114c0
+        value = 0x01

--- a/patches/425307E3 - Dishonored (Europe, USA)(TU4).patch.toml
+++ b/patches/425307E3 - Dishonored (Europe, USA)(TU4).patch.toml
@@ -1,0 +1,51 @@
+title_name = "Dishonored" # TU4
+title_id = "425307E3" # BS-2019
+hash = "ED822C700FE29D2D" # default.xex
+#media_id = [
+#    "76D06EBB", # Disc (Europe): http://redump.org/disc/36105
+#    "4FEBCE15"  # Disc (Europe): http://redump.org/disc/72633
+#    "17FDBCB6"  # Disc (USA):    http://redump.org/disc/41939
+#]
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82461838
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82b025d3
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8277f014
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x834ea644
+        value = 0x01
+    [[patch.be8]]
+        address = 0x834ea650 # Frametime
+        value = 0x01
+
+[[patch]]
+    name = "Show FPS Graph"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x834ea65c
+        value = 0x01

--- a/patches/425307E3 - Dishonored (USA).patch.toml
+++ b/patches/425307E3 - Dishonored (USA).patch.toml
@@ -1,0 +1,47 @@
+title_name = "Dishonored"
+title_id = "425307E3" # BS-2019
+hash = "967D5DD52EF02E20" # default.xex
+#media_id = "17FDBCB6" # Disc (USA): http://redump.org/disc/41939
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8242d4d0
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82a4e9db
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8274a374
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x83410ea4
+        value = 0x01
+    [[patch.be8]]
+        address = 0x83410eb0 # Frametime
+        value = 0x01
+
+[[patch]]
+    name = "Show FPS Graph"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x83410ebc
+        value = 0x01

--- a/patches/425607D3 - Turok (TU2).patch.toml
+++ b/patches/425607D3 - Turok (TU2).patch.toml
@@ -4,8 +4,8 @@ hash = "1FB4E3210AB7A7A9" # default.xex
 #media_id = "3926BB9B" # Disc (USA, Europe): http://redump.org/disc/13439
 
 [[patch]]
-    name = "Unlock FPS"
-    desc = "See note about framerate patches in the README."
+    name = "60 FPS"
+    desc = "See note about framerate patches in the README. Increases vsync target to 60FPS."
     author = "Sowa_95"
     is_enabled = false
 
@@ -38,6 +38,6 @@ hash = "1FB4E3210AB7A7A9" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x834c0021
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x828a2bbf
+        value = 0x00

--- a/patches/425607D3 - Turok.patch.toml
+++ b/patches/425607D3 - Turok.patch.toml
@@ -4,8 +4,8 @@ hash = "C01C5BA21C8272D2" # default.xex
 #media_id = "3926BB9B" # Disc (USA, Europe): http://redump.org/disc/13439
 
 [[patch]]
-    name = "Unlock FPS"
-    desc = "See note about framerate patches in the README."
+    name = "60 FPS"
+    desc = "See note about framerate patches in the README. Increases vsync target to 60FPS."
     author = "Sowa_95"
     is_enabled = false
 
@@ -38,6 +38,6 @@ hash = "C01C5BA21C8272D2" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x834c0021
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x828a29af
+        value = 0x00

--- a/patches/425607ED - Tron Evolution (TU1).patch.toml
+++ b/patches/425607ED - Tron Evolution (TU1).patch.toml
@@ -1,7 +1,7 @@
-title_name = "Hunted: The Demon's Forge"
-title_id = "425307D7" # BS-2007
-hash = "9D75E44A2E84CC51" # default.xex
-#media_id = "7084F7FD" # Disc (USA): http://redump.org/disc/100843
+title_name = "Tron: Evolution" # Disney TRON: Evolution, TU1
+title_id = "425607ED" # BV-2029
+hash = "91B424CA633016BD" # default.xex
+#media_id = "4BB00DF7" # Disc (USA, Europe): http://redump.org/disc/18770
 
 [[patch]]
     name = "Unlock FPS"
@@ -10,10 +10,10 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825f7cb0
+        address = 0x82585dd0
         value = 0x60000000
     [[patch.be8]]
-        address = 0x82d1648f
+        address = 0x82be2537
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
@@ -22,17 +22,17 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82a3783c
+        address = 0x82a087e4
         value = 0x38a00010
 
 [[patch]]
-    name = "Show FPS"
+    name = "Show Frametime"
     author = "Sowa_95"
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x8398cb74
+        address = 0x83658f5c
         value = 0x01
     [[patch.be8]]
-        address = 0x8398cb84 # Frametime
+        address = 0x83658f64
         value = 0x01

--- a/patches/425607ED - Tron Evolution.patch.toml
+++ b/patches/425607ED - Tron Evolution.patch.toml
@@ -1,7 +1,7 @@
-title_name = "Hunted: The Demon's Forge"
-title_id = "425307D7" # BS-2007
-hash = "9D75E44A2E84CC51" # default.xex
-#media_id = "7084F7FD" # Disc (USA): http://redump.org/disc/100843
+title_name = "Tron: Evolution" # Disney TRON: Evolution
+title_id = "425607ED" # BV-2029
+hash = "1E096524EB5AEF06" # default.xex
+#media_id = "4BB00DF7" # Disc (USA, Europe): http://redump.org/disc/18770
 
 [[patch]]
     name = "Unlock FPS"
@@ -10,10 +10,10 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825f7cb0
+        address = 0x825875b0
         value = 0x60000000
     [[patch.be8]]
-        address = 0x82d1648f
+        address = 0x82be1e1f
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
@@ -22,17 +22,17 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82a3783c
+        address = 0x82a094b4
         value = 0x38a00010
 
 [[patch]]
-    name = "Show FPS"
+    name = "Show Frametime"
     author = "Sowa_95"
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x8398cb74
+        address = 0x83658e9c
         value = 0x01
     [[patch.be8]]
-        address = 0x8398cb84 # Frametime
+        address = 0x83658ea4
         value = 0x01

--- a/patches/435907D5 - Enemy Front (TU1).patch.toml
+++ b/patches/435907D5 - Enemy Front (TU1).patch.toml
@@ -1,0 +1,26 @@
+title_name = "Enemy Front" # TU1
+title_id = "435907D5" # CY-2005
+hash = "4796BA1D4BBD38C8" # default.xex
+#media_id = "40C7D6E5" # Disc (USA, Europe): http://redump.org/disc/54086
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x83001538
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x835a650b
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820ea9e2
+        value = 0x60000000

--- a/patches/435907D5 - Enemy Front.patch.toml
+++ b/patches/435907D5 - Enemy Front.patch.toml
@@ -1,0 +1,26 @@
+title_name = "Enemy Front"
+title_id = "435907D5" # CY-2005
+hash = "A2C91F93FB0DF7D8" # default.xex
+#media_id = "40C7D6E5" # Disc (USA, Europe): http://redump.org/disc/54086
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x83000ad8
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x835a5553
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820ea7fa
+        value = 0x60000000

--- a/patches/454108E3 - Crysis 2 (TU4).patch.toml
+++ b/patches/454108E3 - Crysis 2 (TU4).patch.toml
@@ -1,0 +1,26 @@
+title_name = "Crysis 2" # TU4
+title_id = "454108E3" # EA-2275
+hash = "329BA0A669E3A538" # default.xex
+#media_id = "6A9CA6D7" # Disc (World): http://redump.org/disc/35659
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x828939a0
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x836f6307
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8208f9de
+        value = 0x60000000

--- a/patches/454108E3 - Crysis 2.patch.toml
+++ b/patches/454108E3 - Crysis 2.patch.toml
@@ -1,0 +1,26 @@
+title_name = "Crysis 2"
+title_id = "454108E3" # EA-2275
+hash = "5806D7FB6E48CE49" # default.xex
+#media_id = "6A9CA6D7" # Disc (World): http://redump.org/disc/35659
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82883fd0
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x836e009f
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8208f82e
+        value = 0x60000000

--- a/patches/454108EF - Bulletstorm (TU3).patch.toml
+++ b/patches/454108EF - Bulletstorm (TU3).patch.toml
@@ -77,6 +77,18 @@ hash = "6A7504D7D0275AA5" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83540284
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82d33a37
+        value = 0x00
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x833e697c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x833e6988 # Frametime
+        value = 0x01

--- a/patches/454108EF - Bulletstorm.patch.toml
+++ b/patches/454108EF - Bulletstorm.patch.toml
@@ -77,6 +77,18 @@ hash = "D61EAED8BB6A1365" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83500284
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82d32057
+        value = 0x00
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x833d593c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x833d5948 # Frametime
+        value = 0x01

--- a/patches/45410968 - Crysis.patch.toml
+++ b/patches/45410968 - Crysis.patch.toml
@@ -1,0 +1,26 @@
+title_name = "Crysis"
+title_id = "45410968" # EA-2408
+hash = "64FCB384D5B1B42C" # default.xex
+#media_id = "4F4EA672" # XBL Marketplace: 801FA873A37D786F8DB0879D89FCEF5245
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x828147a8
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x831c453f
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8207a170
+        value = 0x60000000

--- a/patches/4541098E - Crysis 3 (TU3).patch.toml
+++ b/patches/4541098E - Crysis 3 (TU3).patch.toml
@@ -1,0 +1,26 @@
+title_name = "Crysis 3" # TU3
+title_id = "4541098E" # EA-2446
+hash = "F6B549D7091155F6" # default.xex
+#media_id = "23955AA4" # Disc (USA, Europe): http://redump.org/disc/52966
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82e105d0
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x836e62d3
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820bf8a6
+        value = 0x60000000

--- a/patches/4541098E - Crysis 3.patch.toml
+++ b/patches/4541098E - Crysis 3.patch.toml
@@ -1,0 +1,26 @@
+title_name = "Crysis 3"
+title_id = "4541098E" # EA-2446
+hash = "66A70FE14B99E819" # default.xex
+#media_id = "23955AA4" # Disc (USA, Europe): http://redump.org/disc/52966
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82e01b10
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x836c5923
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820bf2fa
+        value = 0x60000000

--- a/patches/464F07D1 - IL-2 Sturmovik Birds of Prey.patch.toml
+++ b/patches/464F07D1 - IL-2 Sturmovik Birds of Prey.patch.toml
@@ -1,0 +1,17 @@
+title_name = "IL-2 Sturmovik: Birds of Prey"
+title_id = "464F07D1" # FO-2001
+hash = "E9B716F428A3F741" # default.xex
+#media_id = "794A557F" # Disc (USA, Europe): http://redump.org/disc/74910
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "Doesn't matter if Xenia vsync is enabled or not."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82465750
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x8246575f
+        value = 0x00 # 0x00=unlimited; 0x01=60FPS

--- a/patches/475007D4 - Section 8 (TU1).patch.toml
+++ b/patches/475007D4 - Section 8 (TU1).patch.toml
@@ -51,6 +51,18 @@ hash = "833FCF9A91896897" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83390004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82c6b04f
+        value = 0x00
+
+[[patch]]
+    name = "Show Frametime"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x832dd72c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x832dd734
+        value = 0x01

--- a/patches/475007D4 - Section 8.patch.toml
+++ b/patches/475007D4 - Section 8.patch.toml
@@ -51,6 +51,18 @@ hash = "31A1DD0D102C3129" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83370004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82c5701f
+        value = 0x00
+
+[[patch]]
+    name = "Show Frametime"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x832be08c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x832be094
+        value = 0x01

--- a/patches/4B4E0838 - Blades of Time.patch.toml
+++ b/patches/4B4E0838 - Blades of Time.patch.toml
@@ -1,0 +1,23 @@
+title_name = "Blades of Time"
+title_id = "4B4E0838" # KN-2104
+hash = "6502DB9D18BAEF2A" # default.xex
+#media_id = "70B71AF6" # Disc (USA): http://redump.org/disc/53076
+
+[[patch]]
+    name = "Disable HDR"
+    desc = "Fixes brightness. Not required if readback_resolve enabled."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x821308df
+        value = 0x00
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82085650
+        value = 0x60000000

--- a/patches/4B4E0839 - Birds of Steel.patch.toml
+++ b/patches/4B4E0839 - Birds of Steel.patch.toml
@@ -1,0 +1,17 @@
+title_name = "Birds of Steel"
+title_id = "4B4E0839" # KN-2105
+hash = "E059B2E2EE0C19F1" # default.xex
+#media_id = "54DF8378" # Disc (USA): http://redump.org/disc/51944
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "Doesn't matter if Xenia vsync is enabled or not."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8262d560
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x8262d56f
+        value = 0x00 # 0x00=unlimited; 0x01=60FPS

--- a/patches/4E4D07F1 - Enslaved Odyssey to the West (TU1).patch.toml
+++ b/patches/4E4D07F1 - Enslaved Odyssey to the West (TU1).patch.toml
@@ -1,0 +1,47 @@
+title_name = "Enslaved: Odyssey to the West" # TU1
+title_id = "4E4D07F1" # NM-2033
+hash = "BBD70C6C2FF754FB" # default.xex
+#media_id = "68F2B28B" # Disc (USA, Europe): http://redump.org/disc/16210
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README. FPS higher than 60 can cause an issue in Chapter 13."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825766ec
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82b2673f
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x829bc934
+        value = 0x39600000
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82a7feac
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show Frametime"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8330bdec
+        value = 0x01
+    [[patch.be8]]
+        address = 0x8330bdf4
+        value = 0x01

--- a/patches/4E4D07F1 - Enslaved Odyssey to the West.patch.toml
+++ b/patches/4E4D07F1 - Enslaved Odyssey to the West.patch.toml
@@ -1,0 +1,47 @@
+title_name = "Enslaved: Odyssey to the West"
+title_id = "4E4D07F1" # NM-2033
+hash = "24270DA013B91DF4" # default.xex
+#media_id = "68F2B28B" # Disc (USA, Europe): http://redump.org/disc/16210
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README. FPS higher than 60 can cause an issue in Chapter 13."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824f47e4
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82a8b797
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82935c2c
+        value = 0x39400000
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x829f952c
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show Frametime"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8321824c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x83218254
+        value = 0x01

--- a/patches/5343080B - Batman Arkham Asylum GOTY.patch.toml
+++ b/patches/5343080B - Batman Arkham Asylum GOTY.patch.toml
@@ -17,8 +17,8 @@ hash = "2C06E5E920A8291E" # default.xex
         value = 0x00
 
 [[patch]]
-    name = "Unlock FPS"
-    desc = "See note about framerate patches in the README."
+    name = "60 FPS"
+    desc = "See note about framerate patches in the README. Increases vsync target to 60FPS."
     author = "Sowa_95"
     is_enabled = false
 
@@ -53,11 +53,9 @@ hash = "2C06E5E920A8291E" # default.xex
     [[patch.be8]]
         address = 0x82351d7b
         value = 0x00
-
     [[patch.be8]]
         address = 0x82422ab3
         value = 0x00
-
     [[patch.be8]]
         address = 0x824ac373
         value = 0x00

--- a/patches/535107DA - The Last Remnant.patch.toml
+++ b/patches/535107DA - The Last Remnant.patch.toml
@@ -44,6 +44,6 @@ hash = "E0184D285EBBE8B8" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83560024
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82f2d97f
+        value = 0x00

--- a/patches/53510803 - Thief (TU2).patch.toml
+++ b/patches/53510803 - Thief (TU2).patch.toml
@@ -1,0 +1,17 @@
+title_name = "Thief" # TU2
+title_id = "53510803" # SQ-2051
+hash = "F76E3F7FE75E1B64" # default.xex
+#media_id = "7FF9783D" # Disc (USA, Europe): http://redump.org/disc/50634
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8267a0cc
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x832a8603
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS

--- a/patches/53510803 - Thief.patch.toml
+++ b/patches/53510803 - Thief.patch.toml
@@ -1,0 +1,17 @@
+title_name = "Thief"
+title_id = "53510803" # SQ-2051
+hash = "66FDAEBAB22529E8" # default.xex
+#media_id = "7FF9783D" # Disc (USA, Europe): http://redump.org/disc/50634
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8264a44c
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x83261c6b
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS

--- a/patches/5351081E - Murdered Soul Suspect (TU1).patch.toml
+++ b/patches/5351081E - Murdered Soul Suspect (TU1).patch.toml
@@ -1,0 +1,67 @@
+title_name = "Murdered: Soul Suspect" # TU1
+title_id = "5351081E" # SQ-2078
+hash = "ACAB43DD6B5B0E62" # default.xex
+#media_id = "796B07CA" # Disc (USA, Europe): http://redump.org/disc/59676
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825eb880
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82bd383f
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Ghost Glow Fix"
+    desc = "Eliminates distant objects being visible through ghost glow."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824088ec
+        value = 0x39600000
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82919438
+        value = 0x39400000
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824d27d8
+        value = 0x39600000
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82a84834
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x84cf366c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x84cf3680 # Frametime
+        value = 0x01

--- a/patches/5351081E - Murdered Soul Suspect.patch.toml
+++ b/patches/5351081E - Murdered Soul Suspect.patch.toml
@@ -1,0 +1,67 @@
+title_name = "Murdered: Soul Suspect"
+title_id = "5351081E" # SQ-2078
+hash = "B2682D54AB44B0F7" # default.xex
+#media_id = "796B07CA" # Disc (USA, Europe): http://redump.org/disc/59676
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x825eb7b8
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82bd382f
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Ghost Glow Fix"
+    desc = "Eliminates distant objects being visible through ghost glow."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82408984
+        value = 0x39600000
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82919388
+        value = 0x39400000
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x824d2850
+        value = 0x39600000
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82a84824
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x84cf3664
+        value = 0x01
+    [[patch.be8]]
+        address = 0x84cf3678 # Frametime
+        value = 0x01

--- a/patches/5454087C - Borderlands 2 (TU14).patch.toml
+++ b/patches/5454087C - Borderlands 2 (TU14).patch.toml
@@ -31,6 +31,6 @@ hash = "6E3935C259817E40" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83bd0004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x83216b87
+        value = 0x00

--- a/patches/5454087C - Borderlands 2.patch.toml
+++ b/patches/5454087C - Borderlands 2.patch.toml
@@ -31,6 +31,6 @@ hash = "7902273991112C47" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83b00004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x83190587
+        value = 0x00

--- a/patches/545408AE - XCOM Enemy Within (TU1).patch.toml
+++ b/patches/545408AE - XCOM Enemy Within (TU1).patch.toml
@@ -1,4 +1,4 @@
-title_name = "XCOM: Enemy Within" # v2.0.1
+title_name = "XCOM: Enemy Within" # TU1
 title_id = "545408AE" # TT-2222
 hash = "6A23BE57D5715B6D" # default.xex
 #media_id = "39BC979B" # Disc (USA, Europe): http://redump.org/disc/72080
@@ -22,9 +22,9 @@ hash = "6A23BE57D5715B6D" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
+    [[patch.be8]]
         address = 0x8271f4c8 # OcclusionStepSize
-        value = 0x39400000
+        value = 0x00
 
 [[patch]]
     name = "16x Anisotropic Filtering"

--- a/patches/545408B4 - Borderlands The Pre-Sequel! (TU9).patch.toml
+++ b/patches/545408B4 - Borderlands The Pre-Sequel! (TU9).patch.toml
@@ -31,6 +31,6 @@ hash = "4C41A9620B19A503" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83ab0004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x831fba2f
+        value = 0x00

--- a/patches/545408B4 - Borderlands The Pre-Sequel!.patch.toml
+++ b/patches/545408B4 - Borderlands The Pre-Sequel!.patch.toml
@@ -31,6 +31,6 @@ hash = "4FB22DA70D606550" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x839d0004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x83149297
+        value = 0x00

--- a/patches/555307EA - Brothers in Arms Hell's Highway.patch.toml
+++ b/patches/555307EA - Brothers in Arms Hell's Highway.patch.toml
@@ -31,6 +31,18 @@ hash = "5F08144107199D46" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x832f0004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x828843df
+        value = 0x00
+
+[[patch]]
+    name = "Show Frametime"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x832407e8
+        value = 0x01
+    [[patch.be8]]
+        address = 0x832407f0
+        value = 0x01

--- a/patches/5752082C - Middle-Earth Shadow of Mordor (TU2).patch.toml
+++ b/patches/5752082C - Middle-Earth Shadow of Mordor (TU2).patch.toml
@@ -1,0 +1,23 @@
+title_name = "Middle-Earth: Shadow of Mordor" # TU2
+title_id = "5752082C" # WR-2092
+hash = [ # default.xex
+    #"E2608BA58DDDD764", # Disc 1 (Content Install Disc)
+    "12C6F9738F696AD2"   # Disc 2 (Play Disc)
+]
+#media_id = [
+#    "01219FCA", # Disc 1 (World): http://redump.org/disc/38987
+#    "4451D6B8"  # Disc 2 (World): http://redump.org/disc/38988
+#]
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README. Very high FPS can cause issues."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82bea230
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82c35003
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS

--- a/patches/5752082C - Middle-Earth Shadow of Mordor (TU2).patch.toml
+++ b/patches/5752082C - Middle-Earth Shadow of Mordor (TU2).patch.toml
@@ -1,8 +1,8 @@
 title_name = "Middle-Earth: Shadow of Mordor" # TU2
 title_id = "5752082C" # WR-2092
 hash = [ # default.xex
-    #"E2608BA58DDDD764", # Disc 1 (Content Install Disc)
-    "12C6F9738F696AD2"   # Disc 2 (Play Disc)
+    "12C6F9738F696AD2", # Disc 2 (Play Disc)
+    #"E2608BA58DDDD764" # Disc 1 (Content Install Disc)
 ]
 #media_id = [
 #    "01219FCA", # Disc 1 (World): http://redump.org/disc/38987

--- a/patches/5752082C - Middle-Earth Shadow of Mordor.patch.toml
+++ b/patches/5752082C - Middle-Earth Shadow of Mordor.patch.toml
@@ -1,8 +1,8 @@
 title_name = "Middle-Earth: Shadow of Mordor"
 title_id = "5752082C" # WR-2092
 hash = [ # default.xex
-    #"91346A3E96D946BB", # Disc 1 (Content Install Disc)
-    "BB56CDFB30C504B8"   # Disc 2 (Play Disc)
+    "BB56CDFB30C504B8", # Disc 2 (Play Disc)
+    #"91346A3E96D946BB" # Disc 1 (Content Install Disc)
 ]
 #media_id = [
 #    "01219FCA", # Disc 1 (World): http://redump.org/disc/38987

--- a/patches/5752082C - Middle-Earth Shadow of Mordor.patch.toml
+++ b/patches/5752082C - Middle-Earth Shadow of Mordor.patch.toml
@@ -1,0 +1,23 @@
+title_name = "Middle-Earth: Shadow of Mordor"
+title_id = "5752082C" # WR-2092
+hash = [ # default.xex
+    #"91346A3E96D946BB", # Disc 1 (Content Install Disc)
+    "BB56CDFB30C504B8"   # Disc 2 (Play Disc)
+]
+#media_id = [
+#    "01219FCA", # Disc 1 (World): http://redump.org/disc/38987
+#    "4451D6B8"  # Disc 2 (World): http://redump.org/disc/38988
+#]
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README. Very high FPS can cause issues."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82be61f8
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82c30ec3
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS

--- a/patches/58410B45 - Section 8 Prejudice (TU2).patch.toml
+++ b/patches/58410B45 - Section 8 Prejudice (TU2).patch.toml
@@ -34,3 +34,15 @@ hash = "725589D4AB362E87" # default.xex
     [[patch.be32]]
         address = 0x82afe37c
         value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x835642e0
+        value = 0x01
+    [[patch.be8]]
+        address = 0x835642e8 # Frametime
+        value = 0x01

--- a/patches/58410B45 - Section 8 Prejudice.patch.toml
+++ b/patches/58410B45 - Section 8 Prejudice.patch.toml
@@ -41,6 +41,18 @@ hash = "C32C51664A0E3167" # default.xex
     author = "Sowa_95"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x83610004
-        value = 0x60000000
+    [[patch.be8]]
+        address = 0x82eca03f
+        value = 0x00
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x83558ae0
+        value = 0x01
+    [[patch.be8]]
+        address = 0x83558ae8 # Frametime
+        value = 0x01

--- a/patches/58410B48 - Dead Block.patch.toml
+++ b/patches/58410B48 - Dead Block.patch.toml
@@ -17,6 +17,15 @@ hash = "89A0E820CBB0755D" # default.xex
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8236ca80
+        value = 0x39600000
+
+[[patch]]
     name = "16x Anisotropic Filtering"
     author = "Sowa_95"
     is_enabled = false
@@ -24,3 +33,15 @@ hash = "89A0E820CBB0755D" # default.xex
     [[patch.be32]]
         address = 0x82972f4c
         value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8320423c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x83204248 # Frametime
+        value = 0x01

--- a/patches/58410B6D - Dungeon Defenders (TU2).patch.toml
+++ b/patches/58410B6D - Dungeon Defenders (TU2).patch.toml
@@ -42,5 +42,17 @@ hash = "803E2C7920B0A202" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x830e0f84
+        address = 0x8291408c
         value = 0x60000000
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82fd105c
+        value = 0x01
+    [[patch.be8]]
+        address = 0x82fd1064 # Frametime
+        value = 0x01

--- a/patches/58410B6D - Dungeon Defenders.patch.toml
+++ b/patches/58410B6D - Dungeon Defenders.patch.toml
@@ -42,5 +42,17 @@ hash = "B3412AA5BC53A2FA" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x830d0f84
+        address = 0x829125f4
         value = 0x60000000
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82fc1054
+        value = 0x01
+    [[patch.be8]]
+        address = 0x82fc105c # Frametime
+        value = 0x01

--- a/patches/584111E8 - State of Decay (TU5).patch.toml
+++ b/patches/584111E8 - State of Decay (TU5).patch.toml
@@ -1,10 +1,24 @@
 title_name = "State of Decay" # TU5
 title_id = "584111E8" # XA-4584
 hash = "EE3D121EE9877C9E" # default.xex
-#media_id = "6F32E742"
+#media_id = "6F32E742" # XBLA: 575B340E3A01D77D7C71736AC3B63886D02F23D958
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x830d3578
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x837a65cb
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
     name = "Disable conditional rendering"
+    desc = "Not required since Canary b447699."
     author = "illusion"
     is_enabled = false
 
@@ -17,3 +31,12 @@ hash = "EE3D121EE9877C9E" # default.xex
     [[patch.be32]]
         address = 0x831394cc
         value = 0x39200000
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820f273c
+        value = 0x60000000

--- a/patches/584111E8 - State of Decay.patch.toml
+++ b/patches/584111E8 - State of Decay.patch.toml
@@ -1,0 +1,26 @@
+title_name = "State of Decay"
+title_id = "584111E8" # XA-4584
+hash = "DE77FE6490F9E7F5" # default.xex
+#media_id = "6F32E742" # XBLA: 575B340E3A01D77D7C71736AC3B63886D02F23D958
+
+[[patch]]
+    name = "Unlock FPS"
+    desc = "See note about framerate patches in the README."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x830d1400
+        value = 0x60000000
+    [[patch.be8]]
+        address = 0x8376f0d3
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Skip intro"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x820f4c2c
+        value = 0x60000000

--- a/patches/58411329 - Sanctum 2.patch.toml
+++ b/patches/58411329 - Sanctum 2.patch.toml
@@ -17,6 +17,15 @@ hash = "F99F86F328FDF4B9" # default.xex
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823dbba8
+        value = 0x39600000
+
+[[patch]]
     name = "16x Anisotropic Filtering"
     author = "Sowa_95"
     is_enabled = false
@@ -24,3 +33,15 @@ hash = "F99F86F328FDF4B9" # default.xex
     [[patch.be32]]
         address = 0x8293568c
         value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x8378f834
+        value = 0x01
+    [[patch.be8]]
+        address = 0x8378f848 # Frametime
+        value = 0x01

--- a/patches/584113C2 - Teenage Mutant Ninja Turtles Out of the Shadows.patch.toml
+++ b/patches/584113C2 - Teenage Mutant Ninja Turtles Out of the Shadows.patch.toml
@@ -1,0 +1,54 @@
+title_name = "Teenage Mutant Ninja Turtles: Out of the Shadows" # TMNT:OOTS
+title_id = "584113C2" # XA-5058
+hash = "165D0A96E1707894" # default.xex
+#media_id = "3A067010" # XBLA: 96F6959E5FFEC726B7BB8E8F21A489E78AA809DD58
+
+[[patch]]
+    name = "60 FPS"
+    desc = "See note about framerate patches in the README. Increases vsync target to 60FPS."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x82a7b94f
+        value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x828692c8
+        value = 0x39400000
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82421e18
+        value = 0x39600000
+
+[[patch]]
+    name = "16x Anisotropic Filtering"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8297f49c
+        value = 0x38a00010
+
+[[patch]]
+    name = "Show FPS"
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x838b2978
+        value = 0x01
+    [[patch.be8]]
+        address = 0x838b298c # Frametime
+        value = 0x01

--- a/patches/584113FE - Flashback (TU1).patch.toml
+++ b/patches/584113FE - Flashback (TU1).patch.toml
@@ -1,7 +1,7 @@
-title_name = "Hunted: The Demon's Forge"
-title_id = "425307D7" # BS-2007
-hash = "9D75E44A2E84CC51" # default.xex
-#media_id = "7084F7FD" # Disc (USA): http://redump.org/disc/100843
+title_name = "Flashback" # TU1
+title_id = "584113FE" # XA-5118
+hash = "F0714444D8288246" # default.xex
+#media_id = "27960299" # XBLA: AE7FE87EEDAD897576C94D13BC0E04C523B8B01658
 
 [[patch]]
     name = "Unlock FPS"
@@ -10,11 +10,21 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825f7cb0
+        address = 0x8253b130
         value = 0x60000000
     [[patch.be8]]
-        address = 0x82d1648f
+        address = 0x82ad7b27
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82878f48
+        value = 0x39400000
 
 [[patch]]
     name = "16x Anisotropic Filtering"
@@ -22,7 +32,7 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82a3783c
+        address = 0x8298f194
         value = 0x38a00010
 
 [[patch]]
@@ -31,8 +41,8 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x8398cb74
+        address = 0x83916448
         value = 0x01
     [[patch.be8]]
-        address = 0x8398cb84 # Frametime
+        address = 0x8391645c # Frametime
         value = 0x01

--- a/patches/584113FE - Flashback.patch.toml
+++ b/patches/584113FE - Flashback.patch.toml
@@ -1,7 +1,7 @@
-title_name = "Hunted: The Demon's Forge"
-title_id = "425307D7" # BS-2007
-hash = "9D75E44A2E84CC51" # default.xex
-#media_id = "7084F7FD" # Disc (USA): http://redump.org/disc/100843
+title_name = "Flashback"
+title_id = "584113FE" # XA-5118
+hash = "AD76DCA3312AEB24" # default.xex
+#media_id = "27960299" # XBLA: AE7FE87EEDAD897576C94D13BC0E04C523B8B01658
 
 [[patch]]
     name = "Unlock FPS"
@@ -10,11 +10,21 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x825f7cb0
+        address = 0x82539500
         value = 0x60000000
     [[patch.be8]]
-        address = 0x82d1648f
+        address = 0x82ad5287
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
+
+[[patch]]
+    name = "Disable Lens Flares"
+    desc = "Fixes unoccluded bright lights on-screen."
+    author = "Sowa_95"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82878c18
+        value = 0x39400000
 
 [[patch]]
     name = "16x Anisotropic Filtering"
@@ -22,7 +32,7 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x82a3783c
+        address = 0x8298efcc
         value = 0x38a00010
 
 [[patch]]
@@ -31,8 +41,8 @@ hash = "9D75E44A2E84CC51" # default.xex
     is_enabled = false
 
     [[patch.be8]]
-        address = 0x8398cb74
+        address = 0x83916448
         value = 0x01
     [[patch.be8]]
-        address = 0x8398cb84 # Frametime
+        address = 0x8391645c # Frametime
         value = 0x01


### PR DESCRIPTION
Disable Coalesced check properly instead of skipping the file. Same result but cleaner, and Coalesced for other regions can also be edited, not only int.