### PR TITLE
Update 544307D1 - DEAD OR ALIVE 4.patch.toml

### DIFF
--- a/patches/544307D1 - DEAD OR ALIVE 4.patch.toml
+++ b/patches/544307D1 - DEAD OR ALIVE 4.patch.toml
@@ -74,7 +74,7 @@ hash = "7F840B8DEFDB5C5E" # default.xex
         value = 0x3ed80000
 
 [[patch]]
-    name = "Unused Helena 'Opera' Costume on Slot 1"
+    name = "Cinematic-Only Helena 'Opera' Costume on Slot 1"
     author = "ryu_highabusa"
     is_enabled = false
 
@@ -95,7 +95,7 @@ hash = "7F840B8DEFDB5C5E" # default.xex
         value = 0x03
 
 [[patch]]
-    name = "Unused Christie Costume on Slot 1"
+    name = "Cinematic-Only Christie Costume on Slot 1"
     author = "ryu_highabusa"
     is_enabled = false
 

--- a/patches/544307D1 - DEAD OR ALIVE 4.patch.toml
+++ b/patches/544307D1 - DEAD OR ALIVE 4.patch.toml
@@ -95,7 +95,7 @@ hash = "7F840B8DEFDB5C5E" # default.xex
         value = 0x03
 
 [[patch]]
-    name = "Cinematic-Only Christie Costume on Slot 1"
+    name = "Cutscene-Only Christie Costume on Slot 1"
     author = "ryu_highabusa"
     is_enabled = false
 

--- a/patches/544307D1 - DEAD OR ALIVE 4.patch.toml
+++ b/patches/544307D1 - DEAD OR ALIVE 4.patch.toml
@@ -74,7 +74,7 @@ hash = "7F840B8DEFDB5C5E" # default.xex
         value = 0x3ed80000
 
 [[patch]]
-    name = "Cinematic-Only Helena 'Opera' Costume on Slot 1"
+    name = "Cutscene-Only Helena 'Opera' Costume on Slot 1"
     author = "ryu_highabusa"
     is_enabled = false
 


### PR DESCRIPTION
For base DOA 4. Helenas 'opera' and christie's costume are cinematics only and never meant to fight with, meaning those aren't unused unlike Kokoro's. Don't hesitate to rename my changes because English isn't my main language and cinematic-only seems clear albeit sounding a bit janky.