### PR TITLE
Update, rename 45410914 - Rock Band 3 TU5.patch.toml

### DIFF
--- a/patches/45410914 - Rock Band 3 (TU5).patch.toml
+++ b/patches/45410914 - Rock Band 3 (TU5).patch.toml
@@ -2,7 +2,8 @@ title_name = "Rock Band 3" # Three
 title_id = "45410914" # EA-2324
 hash = [
     "464451C1022FFF32", # EA disc default.xex + TU5 applied
-    "51C7133FD9E500E8"  # RB3DX current xex modded pre-patched with fast start, no song blacklist, anti debugger check, ugc demo patch, and no checksum
+    "51C7133FD9E500E8", # RB3DX current xex modded pre-patched with fast start, no song blacklist, anti debugger check, ugc demo patch, and no checksum
+    "8AAC25DB8A376427"  # RB3DX current xex modded with previous patches and security issue fix (commit 12ff022 on RB3DX repo, 2025/03/08)
 ]
 #media_id = "4FC9256F" # Disc (USA, Europe): http://redump.org/disc/43236
 


### PR DESCRIPTION
Added hash for new RB3 executables distributed as part of Rock Band 3 Deluxe. These were updated to fix an exploit in the game engine which could be used to execute arbitrary code (and was publicly exploited in the game Rock Band Blitz, which uses the same base engine, as an entry point for the BadUpdate exploit). 
Also renames the TU5 patch file to use brackets for consistency with the majority of the patch set.