### PR TITLE
Call of Duty - World at War (Sep 27, 2008 Prototype)

### DIFF
--- a/patches/4156081C - Call of Duty - World at War (Sep 27, 2008 Prototype) (MP).patch.toml
+++ b/patches/4156081C - Call of Duty - World at War (Sep 27, 2008 Prototype) (MP).patch.toml
@@ -1,0 +1,24 @@
+title_name = "Call of Duty - World at War (Sep 27, 2008 Prototype)" # MP
+title_id = "4156081C" # AV-2076
+hash = "996333F652838DCF" # CoDMP.exe
+#media_id = "00000000"
+
+[[patch]]
+    name = "Fixed on-startup crash"
+    desc = "Something related to memory."
+    author = "Adrian"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8246d39c
+        value = 0x60000000
+
+[[patch]]
+    name = "Fixed black screen on start-up"
+    desc = "Skip connecting to blackbox server."
+    author = "Adrian"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x828726a8
+        value = 0x60000000

--- a/patches/4156081C - Call of Duty - World at War (Sep 27, 2008 Prototype) (SP).patch.toml
+++ b/patches/4156081C - Call of Duty - World at War (Sep 27, 2008 Prototype) (SP).patch.toml
@@ -1,0 +1,34 @@
+title_name = "Call of Duty - World at War (Sep 27, 2008 Prototype)" # SP
+title_id = "4156081C" # AV-2076
+hash = "CA4035D9F3A3B290" # CoDSP.exe
+#media_id = "00000000"
+
+[[patch]]
+    name = "Fixed on-startup crash"
+    desc = "Something related to memory."
+    author = "Adrian"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x823caac0
+        value = 0x60000000
+
+[[patch]]
+    name = "Toggle r_drawEntities"
+    desc = "Toggle entity rendering. Disabling r_drawEntities prevents missions from crashing, however characters will no longer render."
+    author = "Adrian"
+    is_enabled = false
+
+    [[patch.be8]]
+        address = 0x825e912b
+        value = 0x0 # 0x1 to enable
+
+[[patch]]
+    name = "Fixed black screen on start-up"
+    desc = "Skip connecting to blackbox server."
+    author = "Adrian"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82556ef0
+        value = 0x60000000


### PR DESCRIPTION
Fixed Call of Duty - World at War (Sep 27, 2008) debug builds crashing on start-up.