### PR TITLE
Add TTT2 "Reduce input lag" patch

### DIFF
--- a/patches/4E4D0859 - TEKKEN TAG 2 (TU0).patch.toml
+++ b/patches/4E4D0859 - TEKKEN TAG 2 (TU0).patch.toml
@@ -1,7 +1,7 @@
 title_name = "TEKKEN TAG 2"
-title_id = "4E4D0859" #NM-2137
-hash = "CA0E150A3A39374E" #default.xex TU0
-#media_id = "5D762D06" #Disc (USA, Europe): http://redump.org/disc/57385
+title_id = "4E4D0859" # NM-2137
+hash = "CA0E150A3A39374E" # default.xex TU0
+#media_id = "5D762D06" # Disc (USA, Europe): http://redump.org/disc/57385
 
 [[patch]]
     name = "Reduce input lag"
@@ -11,4 +11,4 @@ hash = "CA0E150A3A39374E" #default.xex TU0
 
     [[patch.be32]]
         address = 0x8224c1a8
-        value = 0x60000000 #aob:908300003D008200->600000003D008200
+        value = 0x60000000 # aob:908300003D008200->600000003D008200

--- a/patches/4E4D0859 - TEKKEN TAG 2 (TU1).patch.toml
+++ b/patches/4E4D0859 - TEKKEN TAG 2 (TU1).patch.toml
@@ -1,7 +1,7 @@
 title_name = "TEKKEN TAG 2"
-title_id = "4E4D0859" #NM-2137
-hash = "3803382B9FB0921F" #default.xex TU1
-#media_id = "5D762D06" #Disc (USA, Europe): http://redump.org/disc/57385
+title_id = "4E4D0859" # NM-2137
+hash = "3803382B9FB0921F" # default.xex TU1
+#media_id = "5D762D06" # Disc (USA, Europe): http://redump.org/disc/57385
 
 [[patch]]
     name = "Reduce input lag"
@@ -11,4 +11,4 @@ hash = "3803382B9FB0921F" #default.xex TU1
 
     [[patch.be32]]
         address = 0x8225c1c0
-        value = 0x60000000 #aob:908300003D008200->600000003D008200
+        value = 0x60000000 # aob:908300003D008200->600000003D008200


### PR DESCRIPTION
A mod that removes the forced "baked-in" input lag of Tekken Tag Tournament 2.

Same as its RPCS3 and Cemu counterparts:
https://wiki.rpcs3.net/index.php?title=Tekken_Tag_Tournament_2#Patches
https://github.com/cemu-project/cemu_graphic_packs/pull/734

I would like to make it `is_enabled = true` by default (just like Cemu) since there's really no downside to less lag, but the README forbids this for PRs :\