### PR TITLE
Add patch for Golden Axe (XBLA) [58410862]

### DIFF
--- a/patches/58410862 - Golden Axe.patch.toml
+++ b/patches/58410862 - Golden Axe.patch.toml
@@ -1,0 +1,50 @@
+title_name = "Golden Axe" # Sega Vintage Collection (XBLA)
+title_id = "58410862" # XA-2146
+hash = "E144DC735E6D9883" # default.xex
+#media_id = "5A27A44F"
+
+[[patch]]
+    name = "Skip Xbox Live init (fixes Press Start hang)"
+    desc = "M2's firmware shell opens a Live matchmaking listen-socket on port 1000 and waits forever for an inbound Live infrastructure handshake. Patches network import stubs so the shell takes the offline code path and reaches gameplay."
+    author = "preservation-pipeline"
+    is_enabled = false
+
+    # NetDll_socket -> li r3, -1 ; blr  (return INVALID_SOCKET)
+    [[patch.be32]]
+        address = 0x822c841c
+        value = 0x3860ffff
+    [[patch.be32]]
+        address = 0x822c8420
+        value = 0x4e800020
+
+    # NetDll_bind -> li r3, -1 ; blr  (defense in depth)
+    [[patch.be32]]
+        address = 0x822c844c
+        value = 0x3860ffff
+    [[patch.be32]]
+        address = 0x822c8450
+        value = 0x4e800020
+
+    # NetDll_listen -> li r3, -1 ; blr  (defense in depth)
+    [[patch.be32]]
+        address = 0x822c846c
+        value = 0x3860ffff
+    [[patch.be32]]
+        address = 0x822c8470
+        value = 0x4e800020
+
+    # NetDll_XNetStartup -> li r3, 1 ; blr  (defense in depth)
+    [[patch.be32]]
+        address = 0x822c838c
+        value = 0x38600001
+    [[patch.be32]]
+        address = 0x822c8390
+        value = 0x4e800020
+
+    # NetDll_XNetGetEthernetLinkStatus -> li r3, 0 ; blr  (defense in depth)
+    [[patch.be32]]
+        address = 0x822c83fc
+        value = 0x38600000
+    [[patch.be32]]
+        address = 0x822c8400
+        value = 0x4e800020


### PR DESCRIPTION
## Summary
Adds a patch for **Golden Axe** (XBLA, Title ID `58410862`) that skips Xbox Live network initialization. Without this patch the title hangs indefinitely at *Press Start* in Xenia Canary because M2's firmware shell waits forever for an Xbox Live infrastructure handshake.

## Root cause (from debug-level Xenia log analysis)
The M2-built firmware shell does the following at startup:

1. `NetDll_XNetStartup` ✓
2. `NetDll_XNetGetEthernetLinkStatus` → returns "link up" (default)
3. `NetDll_socket(family=1, type=2, proto=0xFE)` → opens an XNet raw socket
4. `NetDll_bind(socket, port=1000)` → Xbox Live secure-gateway port
5. `NetDll_listen(socket, backlog=INT_MAX)`
6. Enters a polling loop on `NetDll_recvfrom` / `NetDll_accept` (via C++ vtable dispatch through `~0x8232D3C4`), waiting for an inbound Live infrastructure packet that no longer arrives in 2026.

The *Press Start* input handler is gated on the same readiness flag that the polling loop is supposed to set, so the title is stuck.

## Fix
Patch the network import stubs at the addresses listed below to return failure. The cascade is:

- `NetDll_socket` returns `-1` → `bind`/`listen` get nothing to attach to
- defense-in-depth: `bind`/`listen` themselves also return `-1`
- defense-in-depth: `XNetStartup` returns non-zero
- defense-in-depth: `XNetGetEthernetLinkStatus` returns `0` ("link down")

Once the network init fails at the syscall level, the M2 shell takes its offline code path and reaches gameplay normally. Tested on Xenia Canary `dc4db67f9` against the LIVE-signed package (module hash `E144DC735E6D9883`).

## Stub addresses
All addresses are from the XEX import-dump that Xenia prints at module load (column 2 — the trampoline address):
```
F 820006A0 822c841c 003 (   3)    NetDll_socket
F 820006AC 822c844c 00B (  11)    NetDll_bind
F 820006B4 822c846c 00D (  13)    NetDll_listen
F 8200067C 822c838c 033 (  51)    NetDll_XNetStartup
F 82000698 822c83fc 04B (  75)    NetDll_XNetGetEthernetLinkStatus
```
Each stub is replaced with the PowerPC sequence `li r3, <N> ; blr` (8 bytes; remainder of the 16-byte stub slot is unreachable after `blr`).

## Test plan
- [x] Title loads in Xenia Canary
- [x] Without the patch: hangs at *Press Start*, log shows the `NetDll_recvfrom`/`accept` busy-loop
- [x] With the patch enabled: no socket/bind/listen ever happens, *Press Start* advances normally
- [x] Patch file passes TOML validation
- [x] Filename matches `Title ID - Game Title.patch.toml` convention
- [x] `is_enabled = false` as required for PRs
- [x] Title ID and hash uppercase; addresses and values lowercase
- [x] Single newline at end of file

## Notes for reviewers
- This is almost certainly applicable to the rest of M2's **Sega Vintage Collection** XBLA line (Streets of Rage, Altered Beast, Sonic, Comix Zone, Vectorman, Gunstar Heroes, etc.) since they share the same firmware shell. The stub addresses will differ per-title because each `default.xex` has its own PE layout — they can be read off Xenia's first-load import dump.
- The patch only ever modifies in-memory image bytes via Xenia's patcher; no asset bytes on disk are touched.