### PR TITLE
Remove patches from The Darkness

### DIFF
--- a/patches/545407EE - The Darkness.patch.toml
+++ b/patches/545407EE - The Darkness.patch.toml
@@ -3,19 +3,6 @@ title_id = "545407EE" # TT-2030
 hash = "29362A3C8309E1AC" # default.xex
 #media_id = "0F213645" # Disc (USA, Europe): http://redump.org/disc/11406
 
-[[patch]]
-    name = "Bright Lighting Fix"
-    desc = "Normalizes specular lighting and bloom exposure."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x822745d0
-        value = 0x3d608206
-    [[patch.be32]]
-        address = 0x822745e0
-        value = 0xc00bc06c
-
 # Credit to patcher Bader for FOV patch, taken from https://www.reddit.com/r/ps4homebrew/comments/o2xe6u/60fps_patch_for_ghost_of_tsushima_ps4_pro_only/h35tfuy
 [[patch]]
     name = "Extended FOV"
@@ -26,13 +13,3 @@ hash = "29362A3C8309E1AC" # default.xex
     [[patch.f32]]
         address = 0x8209dff4
         value = 90
-
-[[patch]]
-    name = "60 FPS"
-    desc = "60 FPS patch"
-    author = "Vex"
-    is_enabled = false
-
-    [[patch.f32]]
-        address = 0x8209de08
-        value = 0.01666666666


### PR DESCRIPTION
Auto-exposure in The Darkness has been fixed, so the crappy lighting patch can finally be taken to the farm upstate and put out of its misery.

And the 60 FPS patch has no reason to exist. None of the game's systems are locked to a 30 FPS tick.