### PR TITLE
Gears 3 & Gears Judgment Ultrawide Patches

### DIFF
--- a/patches/4D5308AB - Gears of War 3 (TU6 Disc; TU1 XBL).patch.toml
+++ b/patches/4D5308AB - Gears of War 3 (TU6 Disc; TU1 XBL).patch.toml
@@ -127,12 +127,6 @@ hash = "7775898137CE1CE3" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x827c9078 # Ignore occlusion queries from gumming up InitViews
-        value = 0x39600001 # li r11, 1
-    [[patch.be32]]
-        address = 0x827caf2c # Skip allocate query pool
-        value = 0x39600001 # li r11, 1
-    [[patch.be32]]
         address = 0x827e2af0 # projected shadow render, gathering draw lists
         value = 0x4bb2edb0 # b 0x823118a0 code cave
     [[patch.be32]]
@@ -190,3 +184,43 @@ hash = "7775898137CE1CE3" # default.xex
     [[patch.be8]]
         address = 0x834398ac # Frametime
         value = 0x01
+
+[[patch]]
+    name = "21:9 Aspect Ratio Ultrawide Patch"
+    desc = "Must set present_letterbox = FALSE in the xenia canary config. Must download GOW3 Fixes zip (found on xenia-game-settings Github Gears 3 wiki page) to prevent UI artifacts when alerts pop up. Expands gameplay, cutscene and UI rendering to true 21:9 ultrawide and updates the FOV axis constraint for proper framing, and adds pillarboxing for pre-rendered videos. Because the game now renders at 1280x550, certain elements may appear more aliased."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.f32]] # GAMEPLAY & CUTSCENE FOV CAN BE ADJUSTED BY INCREASING/DECREASING THIS FIRST FLOAT IN INCREMENTS OF 0.0005
+        address = 0x826096c8
+        value = 0.0109750
+    [[patch.f32]]
+        address = 0x820cded8
+        value = 2.3272
+    [[patch.be32]]
+        address = 0x82bdd3bc
+        value = 0x38800001
+    [[patch.be16]]
+        address = 0x82971c52
+        value = 0x0226
+    [[patch.be32]]
+        address = 0x827d7acc
+        value = 0x3bc002d0
+    [[patch.be16]]
+        address = 0x8262cdf0
+        value = 0x4800
+    [[patch.be32]]
+        address = 0x8262ce80
+        value = 0x4bfdc838
+    [[patch.be32]]
+        address = 0x826096b8
+        value = 0x3d808260
+    [[patch.be32]]
+        address = 0x826096bc
+        value = 0x618c96c8
+    [[patch.be32]]
+        address = 0x826096c0
+        value = 0xc00c0000
+    [[patch.be32]]
+        address = 0x826096c4
+        value = 0x480237c0

--- a/patches/4D5308AB - Gears of War 3.patch.toml
+++ b/patches/4D5308AB - Gears of War 3.patch.toml
@@ -127,12 +127,6 @@ hash = "EF4AD5E9DD1982ED" # default.xex
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x827b6c40 # Ignore occlusion queries from gumming up InitViews
-        value = 0x39600001 # li r11, 1
-    [[patch.be32]]
-        address = 0x827b8af4 # Skip allocate query pool
-        value = 0x39600001 # li r11, 1
-    [[patch.be32]]
         address = 0x827d0878 # projected shadow render, gathering draw lists
         value = 0x4bb309a0 # b 0x82301218 code cave
     [[patch.be32]]
@@ -180,3 +174,43 @@ hash = "EF4AD5E9DD1982ED" # default.xex
     [[patch.be8]]
         address = 0x834290ec # Frametime
         value = 0x01
+
+[[patch]]
+    name = "21:9 Aspect Ratio Ultrawide Patch"
+    desc = "Must set present_letterbox = FALSE in the xenia canary config. Must download GOW3 Fixes zip (found on xenia-game-settings Github Gears Judgment wiki page) and Disable Coalesced Hash Check patch to prevent UI artifacts when alerts pop up. Expands gameplay, cutscene and UI rendering to true 21:9 ultrawide and updates the FOV axis constraint for proper framing, and adds pillarboxing for pre-rendered videos. Because the game now renders at 1280x550, certain elements may appear more aliased."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.f32]] # GAMEPLAY & CUTSCENE FOV CAN BE ADJUSTED BY INCREASING/DECREASING THIS FIRST FLOAT IN INCREMENTS OF 0.0005
+        address = 0x825f8650
+        value = 0.0109750
+    [[patch.f32]]
+        address = 0x820cde2c
+        value = 2.3272
+    [[patch.be32]]
+        address = 0x82bc9d84
+        value = 0x38800001
+    [[patch.be16]]
+        address = 0x82960c7a
+        value = 0x0226
+    [[patch.be32]]
+        address = 0x827c583c
+        value = 0x3bc002d0
+    [[patch.be16]]
+        address = 0x8261be60
+        value = 0x4800
+    [[patch.be32]]
+        address = 0x8261bef0
+        value = 0x4bfdc750 # b 0x825f8640
+    [[patch.be32]]
+        address = 0x825f8640
+        value = 0x3d80825f # lis r12, 0x825f
+    [[patch.be32]]
+        address = 0x825f8644
+        value = 0x618c8650 # stw r12, r12 0x8650
+    [[patch.be32]]
+        address = 0x825f8648
+        value = 0xc00c0000 # lfs f0, 0(r12)
+    [[patch.be32]]
+        address = 0x825f864c
+        value = 0x480238a8 # b 0x8261bef4

--- a/patches/4D530A26 - Gears of War Judgment (TU4).patch.toml
+++ b/patches/4D530A26 - Gears of War Judgment (TU4).patch.toml
@@ -156,6 +156,52 @@ hash = "013148141A27D4C7" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "21:9 Aspect Ratio Ultrawide Patch"
+    desc = "Must set present_letterbox = FALSE in the xenia canary config. Must download Ultrawide Support Patch zip (found on xenia-game-settings Github Gears Judgment wiki page) to prevent UI artifacts when alerts pop up. Expands gameplay and cutscene rendering to true 21:9 ultrawide, updates the FOV axis constraint for proper framing, and adds pillarboxing for pre-rendered videos. Because the game now renders at 1280x550, certain elements may appear more aliased."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.f32]] # GAMEPLAY & CUTSCENE FOV CAN BE ADJUSTED BY INCREASING/DECREASING THIS FIRST FLOAT IN INCREMENTS OF 0.0005
+        address = 0x8261c898
+        value = 0.0109750
+    [[patch.be16]]
+        address = 0x82992666
+        value = 0x0226
+    [[patch.f32]]
+        address = 0x82082c30
+        value = 2.3273
+    [[patch.f32]]
+        address = 0x82083350
+        value = 2.3273
+    [[patch.be16]]
+        address = 0x82640514
+        value = 0x4800
+    [[patch.be32]]
+        address = 0x82369e30 # Vignette needs to be disabled for this mode; texture cannot be rescaled.
+        value = 0x4800000c
+    [[patch.be32]]
+        address = 0x827f1dd4 # Define screen height in SceneRenderTargets, avoid crashing.
+        value = 0x3bc002d0
+    [[patch.be32]]
+        address = 0x82cba684 # Scale Scaleform UI
+        value = 0x38800001
+    [[patch.be32]]
+        address = 0x82640588 # jump to cave
+        value = 0x4bfdc300
+    [[patch.be32]]
+        address = 0x8261c888 # beginning of cave
+        value = 0x3d808261
+    [[patch.be32]]
+        address = 0x8261c88c
+        value = 0x618cc898
+    [[patch.be32]]
+        address = 0x8261c890
+        value = 0xc00c0000
+    [[patch.be32]]
+        address = 0x8261c894
+        value = 0x48023cf8
+
+[[patch]]
     name = "Steam Deck / 16:10 Aspect Ratio Support"
     desc = "Must set present_letterbox = FALSE in the xenia canary config. Designed for Steam Deck and modern gaming laptop displays. Expands gameplay and cutscene rendering to true 16:10, updates the FOV axis constraint for proper framing, and adds pillarboxing for pre-rendered videos."
     author = "TudorHorse, boma"

--- a/patches/4D530A26 - Gears of War Judgment.patch.toml
+++ b/patches/4D530A26 - Gears of War Judgment.patch.toml
@@ -156,6 +156,52 @@ hash = "8429D0AE190C10DB" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "21:9 Ultrawide Aspect Ratio Patch"
+    desc = "Must set present_letterbox = FALSE in the xenia canary config. Must download Ultrawide Support Patch zip (found on xenia-game-settings Github Gears Judgment wiki page) and Disable Coalesced Hash Check patch to prevent UI artifacts when alerts pop up. Expands gameplay and cutscene rendering to true 21:9 ultrawide, updates the FOV axis constraint for proper framing, and adds pillarboxing for pre-rendered videos. Because the game now renders at 1280x550, certain elements may appear more aliased."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.f32]] # GAMEPLAY & CUTSCENE FOV CAN BE ADJUSTED BY INCREASING/DECREASING THIS FIRST FLOAT IN INCREMENTS OF 0.0005
+        address = 0x8261c468
+        value = 0.0109750
+    [[patch.be16]]
+        address = 0x82990abe
+        value = 0x0226
+    [[patch.f32]]
+        address = 0x82083370
+        value = 2.3273
+    [[patch.f32]]
+        address = 0x82082c50
+        value = 2.3273
+    [[patch.be16]]
+        address = 0x826400ec
+        value = 0x4800
+    [[patch.be32]]
+        address = 0x82369a80 # Vignette needs to be disabled for this mode; texture cannot be rescaled.
+        value = 0x4800000c
+    [[patch.be32]]
+        address = 0x827f0ecc # Define screen height in SceneRenderTargets, avoid crashing.
+        value = 0x3bc002d0
+    [[patch.be32]]
+        address = 0x82cb7dbc # Scale Scaleform UI
+        value = 0x38800001
+    [[patch.be32]]
+        address = 0x82640160 # jump to cave
+        value = 0x4bfdc2f8
+    [[patch.be32]]
+        address = 0x8261c458 # beginning of cave
+        value = 0x3d808261
+    [[patch.be32]]
+        address = 0x8261c45c
+        value = 0x618cc468
+    [[patch.be32]]
+        address = 0x8261c460
+        value = 0xc00c0000
+    [[patch.be32]]
+        address = 0x8261c464
+        value = 0x48023d00
+
+[[patch]]
     name = "Steam Deck / 16:10 Aspect Ratio Support"
     desc = "Must set present_letterbox = FALSE in the xenia canary config. Designed for Steam Deck and modern gaming laptop displays. Expands gameplay and cutscene rendering to true 16:10, updates the FOV axis constraint for proper framing, and adds pillarboxing for pre-rendered videos."
     author = "TudorHorse, boma"


### PR DESCRIPTION
Gears 3 - TU0, TU6
Gears Judgment - TU0, TU4

Unfortunately, both games wig out when the little alert message in the lower-right portion of the screen pops up.

The only fix is to patch coalesced (TU0), or drop in a ini in the TU folder, if applicable, and disable those alerts outright. No such patch is possible - it's all simulated functions.

A1eNaZ is already hosting those files on the xenia-game-settings repo.