### PR TITLE
584111E8 - State of Decay

### DIFF
--- a/patches/5351081E - Murdered Soul Suspect (TU1).patch.toml
+++ b/patches/5351081E - Murdered Soul Suspect (TU1).patch.toml
@@ -18,7 +18,7 @@ hash = "ACAB43DD6B5B0E62" # default.xex
 
 [[patch]]
     name = "Ghost Glow Fix"
-    desc = "Eliminates distant objects being visible through ghost glow."
+    desc = "Eliminates distant objects being visible through ghost glow on occlusion_query = fake or fast. Prevents ghost glow flickering on occlusion_query = strict."
     author = "Sowa_95"
     is_enabled = false
 
@@ -28,7 +28,7 @@ hash = "ACAB43DD6B5B0E62" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene."
+    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene. Not required on occlusion_query = strict."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5351081E - Murdered Soul Suspect.patch.toml
+++ b/patches/5351081E - Murdered Soul Suspect.patch.toml
@@ -18,7 +18,7 @@ hash = "B2682D54AB44B0F7" # default.xex
 
 [[patch]]
     name = "Ghost Glow Fix"
-    desc = "Eliminates distant objects being visible through ghost glow."
+    desc = "Eliminates distant objects being visible through ghost glow on occlusion_query = fake or fast. Prevents ghost glow flickering on occlusion_query = strict."
     author = "Sowa_95"
     is_enabled = false
 
@@ -28,7 +28,7 @@ hash = "B2682D54AB44B0F7" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene."
+    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene. Not required on occlusion_query = strict."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/584111E8 - State of Decay (TU5).patch.toml
+++ b/patches/584111E8 - State of Decay (TU5).patch.toml
@@ -18,7 +18,7 @@ hash = "EE3D121EE9877C9E" # default.xex
 
 [[patch]]
     name = "Disable conditional rendering"
-    desc = "Not required since Canary b447699."
+    desc = "Prevents flickering. Not required on occlusion_query = fake."
     author = "illusion"
     is_enabled = false
 
@@ -31,19 +31,6 @@ hash = "EE3D121EE9877C9E" # default.xex
     [[patch.be32]]
         address = 0x831394cc
         value = 0x39200000
-
-[[patch]]
-    name = "Disable most shadows"
-    desc = "Improves visibility in shaded areas. Best paired with Vulkan for better remaining shadows. Can be improved to properly disable all shadows."
-    author = "Sowa_95"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x83115f6c
-        value = 0x39400000
-    [[patch.be32]]
-        address = 0x83115fb8
-        value = 0x39400000
 
 [[patch]]
     name = "Skip intro"

--- a/patches/584111E8 - State of Decay (TU7).patch.toml
+++ b/patches/584111E8 - State of Decay (TU7).patch.toml
@@ -17,17 +17,20 @@ hash = "87C9561D4440AB73" # default.xex
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
-    name = "Disable most shadows"
-    desc = "Improves visibility in shaded areas. Best paired with Vulkan for better remaining shadows. Can be improved to properly disable all shadows."
-    author = "Sowa_95"
+    name = "Disable conditional rendering"
+    desc = "Prevents flickering. Not required on occlusion_query = fake."
+    author = "illusion"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x83116ec4
-        value = 0x39400000
+        address = 0x8313b7b4
+        value = 0x39600000
     [[patch.be32]]
-        address = 0x83116f10
-        value = 0x39400000
+        address = 0x8313b21c
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x8313aac4
+        value = 0x39200000
 
 [[patch]]
     name = "Skip intro"

--- a/patches/584111E8 - State of Decay.patch.toml
+++ b/patches/584111E8 - State of Decay.patch.toml
@@ -17,17 +17,20 @@ hash = "DE77FE6490F9E7F5" # default.xex
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
-    name = "Disable most shadows"
-    desc = "Improves visibility in shaded areas. Best paired with Vulkan for better remaining shadows. Can be improved to properly disable all shadows."
-    author = "Sowa_95"
+    name = "Disable conditional rendering"
+    desc = "Prevents flickering. Not required on occlusion_query = fake."
+    author = "illusion"
     is_enabled = false
 
     [[patch.be32]]
-        address = 0x831148f8
-        value = 0x39400000
+        address = 0x8313a5cc
+        value = 0x39600000
     [[patch.be32]]
-        address = 0x83114944
-        value = 0x39400000
+        address = 0x8313a034
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x831398dc
+        value = 0x39200000
 
 [[patch]]
     name = "Skip intro"


### PR DESCRIPTION
In terms of visuals, shadow patch has no use since Boma's work. It doesn't seem to make a difference for performance either, regardless if CPU or GPU limited, so I'm removing it.

Disable conditional rendering is useful once again. It prevents flickering on fast/strict occlusion, even if readback is disabled. Ported to TU0 and TU7.