### PR TITLE
UE3 OQ Fixes, Misc Cleanup

### DIFF
--- a/patches/354807D1 - Painkiller Hell & Damnation (TU1).patch.toml
+++ b/patches/354807D1 - Painkiller Hell & Damnation (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "56209C4732826FCF" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/354807D1 - Painkiller Hell & Damnation.patch.toml
+++ b/patches/354807D1 - Painkiller Hell & Damnation.patch.toml
@@ -18,7 +18,6 @@ hash = "C93226A24A871C0E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/354807D5 - Deadfall Adventures (TU1).patch.toml
+++ b/patches/354807D5 - Deadfall Adventures (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "F9BDA57D6CAA0565" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/354807D5 - Deadfall Adventures.patch.toml
+++ b/patches/354807D5 - Deadfall Adventures.patch.toml
@@ -18,7 +18,6 @@ hash = "088C950FC9389B09" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/415607E1 - Call Of Duty 3 (TU3).patch.toml
+++ b/patches/415607E1 - Call Of Duty 3 (TU3).patch.toml
@@ -28,7 +28,6 @@ hash = "7CAEC18CD0C372B6" # default.xex # TU3
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Clippy95, fragsareus"
     is_enabled = false
 

--- a/patches/415607E1 - Call Of Duty 3 MP (TU3).patch.toml
+++ b/patches/415607E1 - Call Of Duty 3 MP (TU3).patch.toml
@@ -31,7 +31,6 @@ hash = "C4EA5EACCA7CA7CD" # codmp_xenonf.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Clippy95, fragsareus"
     is_enabled = false
 

--- a/patches/415607E1 - Call Of Duty 3 MP.patch.toml
+++ b/patches/415607E1 - Call Of Duty 3 MP.patch.toml
@@ -31,7 +31,6 @@ hash = "D1CC65DC0F0C0CBB" # codmp_xenonf.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Clippy95, fragsareus"
     is_enabled = false
 

--- a/patches/415607E1 - Call Of Duty 3.patch.toml
+++ b/patches/415607E1 - Call Of Duty 3.patch.toml
@@ -28,7 +28,6 @@ hash = "B796871E700C5C6B" # default.xex # TU0
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Clippy95, fragsareus"
     is_enabled = false
 

--- a/patches/4156084C - Transformers War for Cybertron (TU1).patch.toml
+++ b/patches/4156084C - Transformers War for Cybertron (TU1).patch.toml
@@ -30,7 +30,6 @@ hash = "3AF46199AE02D5C7" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4156084C - Transformers War for Cybertron.patch.toml
+++ b/patches/4156084C - Transformers War for Cybertron.patch.toml
@@ -30,7 +30,6 @@ hash = "0D6CA1E3F19F0087" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4156089C - Transformers Fall of Cybertron (TU1).patch.toml
+++ b/patches/4156089C - Transformers Fall of Cybertron (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "BD692426D88575FB" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4156089C - Transformers Fall of Cybertron (TU2).patch.toml
+++ b/patches/4156089C - Transformers Fall of Cybertron (TU2).patch.toml
@@ -18,7 +18,6 @@ hash = "CD1E22093B0ACD1E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4156089C - Transformers Fall of Cybertron.patch.toml
+++ b/patches/4156089C - Transformers Fall of Cybertron.patch.toml
@@ -18,7 +18,6 @@ hash = "71315618DA5F8510" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/415608AF - GoldenEye 007 Reloaded.patch.toml
+++ b/patches/415608AF - GoldenEye 007 Reloaded.patch.toml
@@ -4,8 +4,7 @@ hash = "065D6021C0BDD535" # default.xex
 #media_id = "40583A82" # Disc (USA, Europe): https://redump.info/disc/38456
 
 [[patch]]
-    name = "Lens Flare Occlusion Fix"
-    desc = "Fixes bright lights that aren't properly occluded."
+    name = "Disable Lens Flares"
     author = "boma"
     is_enabled = false
 

--- a/patches/415608EC - Deadpool.patch.toml
+++ b/patches/415608EC - Deadpool.patch.toml
@@ -18,7 +18,6 @@ hash = "5F598C9C0797823D" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "HouseofTudor"
     is_enabled = false
 

--- a/patches/41560904 - Transformers-Rise of The Dark Spark.patch.toml
+++ b/patches/41560904 - Transformers-Rise of The Dark Spark.patch.toml
@@ -18,7 +18,6 @@ hash = "5821E90CE3C7FBB3" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/425607ED - Tron Evolution (TU1).patch.toml
+++ b/patches/425607ED - Tron Evolution (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "91B424CA633016BD" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/425607ED - Tron Evolution.patch.toml
+++ b/patches/425607ED - Tron Evolution.patch.toml
@@ -18,7 +18,6 @@ hash = "1E096524EB5AEF06" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4343082F - Remember Me.patch.toml
+++ b/patches/4343082F - Remember Me.patch.toml
@@ -18,7 +18,6 @@ hash = "EC584EF58089DFCD" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/43430830 - Lost Planet 3 (TU1).patch.toml
+++ b/patches/43430830 - Lost Planet 3 (TU1).patch.toml
@@ -18,23 +18,12 @@ hash = "2D722B68C09659CD" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
         address = 0x82b07358
         value = 0x39400000
-
-[[patch]]
-    name = "RTV - Decals Fix"
-    desc = "Disables static decals that cause flickering with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x822eea48
-        value = 0x39600000
 
 [[patch]]
     name = "16x Anisotropic Filtering"

--- a/patches/43430830 - Lost Planet 3.patch.toml
+++ b/patches/43430830 - Lost Planet 3.patch.toml
@@ -18,23 +18,12 @@ hash = "3F74E86B6D9AC1C8" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
         address = 0x82b08160
         value = 0x39400000
-
-[[patch]]
-    name = "RTV - Decals Fix"
-    desc = "Disables static decals that cause flickering with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x822ee938
-        value = 0x39600000
 
 [[patch]]
     name = "16x Anisotropic Filtering"

--- a/patches/454107F8 - Army of Two (USA).patch.toml
+++ b/patches/454107F8 - Army of Two (USA).patch.toml
@@ -27,49 +27,6 @@ hash = "2EDC4C4CEC3F7F8D" # default.xex
         value = 0x04
 
 [[patch]]
-    name = "Flickering Decals Fix"
-    desc = "Fixes decals (bloodpools, bullet holes, etc.) that flicker when using the Vulkan FBO or D3D12 RTV render paths."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82894c44 # BSP receivers
-        value = 0x4be47d24 # b 0x826dc968
-    [[patch.be32]]
-        address = 0x826dc968 # BSP code cave
-        value = 0x3c00bc23 # lis r0, 0xbc23
-    [[patch.be32]]
-        address = 0x826dc96c
-        value = 0x6000d70a # ori r0, r0, 0xd70a
-    [[patch.be32]]
-        address = 0x826dc970
-        value = 0x900101f0 # stw r0, 0x01f0(r1)
-    [[patch.be32]]
-        address = 0x826dc974 # Clamp DepthBias to -0.01f
-        value = 0xc00101f0 # lfs f0, 0x01f0(r1)
-    [[patch.be32]]
-        address = 0x826dc978
-        value = 0x481b82d0 # b 0x82894c48
-    [[patch.be32]]
-        address = 0x82894800 # Static mesh receivers
-        value = 0x4be48180 # b 0x826dc980
-    [[patch.be32]]
-        address = 0x826dc980 # Static mesh code cave
-        value = 0x3c00bc23 # lis r0, 0xbc23
-    [[patch.be32]]
-        address = 0x826dc984
-        value = 0x6000d70a # ori r0, r0, 0xd70a
-    [[patch.be32]]
-        address = 0x826dc988
-        value = 0x900101b0 # stw r0, 0x01b0(r1)
-    [[patch.be32]]
-        address = 0x826dc98c # Clamp DepthBias to -0.01f
-        value = 0xc00101b0 # lfs f0, 0x01b0(r1)
-    [[patch.be32]]
-        address = 0x826dc990
-        value = 0x481b7e74 # b 0x82894804
-
-[[patch]]
     name = "Upscaling Fix - Disable Gaussian Blur (sharper, less bloom/DoF)"
     desc = "Forces the blur radius to 0, disabling gaussian blur. Helps upscaling without having to disable all post-processing."
     author = "boma"

--- a/patches/45410850 - Mirror's Edge (TU2).patch.toml
+++ b/patches/45410850 - Mirror's Edge (TU2).patch.toml
@@ -34,7 +34,6 @@ hash = "64079AA28F886F3C" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma, Sowa_95"
     is_enabled = false
 

--- a/patches/45410850 - Mirror's Edge.patch.toml
+++ b/patches/45410850 - Mirror's Edge.patch.toml
@@ -34,7 +34,6 @@ hash = "25AA0820DF95AA47" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/454108CE - Mass Effect 2 (TU2).patch.toml
+++ b/patches/454108CE - Mass Effect 2 (TU2).patch.toml
@@ -52,7 +52,6 @@ hash = "3D790F44F99FCF0E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen without breaking interactibles."
     author = "HouseofTudor"
     is_enabled = false
 

--- a/patches/454108CE - Mass Effect 2.patch.toml
+++ b/patches/454108CE - Mass Effect 2.patch.toml
@@ -52,7 +52,6 @@ hash = "2F1248679FD451B2" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen without breaking interactibles."
     author = "HouseofTudor"
     is_enabled = false
 

--- a/patches/454108D8 - Army of Two The 40th Day (TU3).patch.toml
+++ b/patches/454108D8 - Army of Two The 40th Day (TU3).patch.toml
@@ -21,7 +21,6 @@ hash = [
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/454108D8 - Army of Two The 40th Day.patch.toml
+++ b/patches/454108D8 - Army of Two The 40th Day.patch.toml
@@ -21,7 +21,6 @@ hash = [
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/454108EF - Bulletstorm (TU3).patch.toml
+++ b/patches/454108EF - Bulletstorm (TU3).patch.toml
@@ -18,23 +18,12 @@ hash = "6A7504D7D0275AA5" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
         address = 0x8293dbe8
         value = 0x39400000
-
-[[patch]]
-    name = "RTV - Flickering Decals Fix"
-    desc = "Disables static decals that cause z-fighting with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x8232f070
-        value = 0x39200000
 
 [[patch]]
     name = "16x Anisotropic Filtering"

--- a/patches/454108EF - Bulletstorm.patch.toml
+++ b/patches/454108EF - Bulletstorm.patch.toml
@@ -18,23 +18,12 @@ hash = "D61EAED8BB6A1365" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
         address = 0x8293c978
         value = 0x39400000
-
-[[patch]]
-    name = "RTV - Flickering Decals Fix"
-    desc = "Disables static decals that cause z-fighting with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x8232e680
-        value = 0x39200000
 
 [[patch]]
     name = "16x Anisotropic Filtering"

--- a/patches/45410916 - Alice Madness Returns.patch.toml
+++ b/patches/45410916 - Alice Madness Returns.patch.toml
@@ -5,7 +5,6 @@ hash = "2FD7D2F9D7F51AEA" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
@@ -22,16 +21,6 @@ hash = "2FD7D2F9D7F51AEA" # default.xex
     [[patch.be32]]
         address = 0x8242fd24
         value = 0x60000000
-
-[[patch]]
-    name = "RTV - Decals Fix"
-    desc = "Disables static decals that cause flickering with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x8235e1d4
-        value = 0x39600000
 
 [[patch]]
     name = "16x Anisotropic Filtering"

--- a/patches/464507DF - Sherlock Holmes Crimes & Punishments.patch.toml
+++ b/patches/464507DF - Sherlock Holmes Crimes & Punishments.patch.toml
@@ -18,7 +18,6 @@ hash = "33F439B38AA965C0" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/475007D3 - Legendary.patch.toml
+++ b/patches/475007D3 - Legendary.patch.toml
@@ -28,7 +28,6 @@ hash = "03B014AB8C6401D3" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/475007D4 - Section 8 (TU1).patch.toml
+++ b/patches/475007D4 - Section 8 (TU1).patch.toml
@@ -28,7 +28,6 @@ hash = "833FCF9A91896897" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/475007D4 - Section 8.patch.toml
+++ b/patches/475007D4 - Section 8.patch.toml
@@ -28,7 +28,6 @@ hash = "31A1DD0D102C3129" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/475807D1 - Lucha Libre AAA Heroes del Ring.patch.toml
+++ b/patches/475807D1 - Lucha Libre AAA Heroes del Ring.patch.toml
@@ -36,16 +36,6 @@ hash = "2A412C79F6E775B1" # default.xex
         value = 0x39600000
 
 [[patch]]
-    name = "RTV - Flickering Decals Fix"
-    desc = "Disables static decals that cause z-fighting with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82317f7c # StaticDecals = FALSE
-        value = 0x39200000
-
-[[patch]]
     name = "16x Anisotropic Filtering"
     author = "boma"
     is_enabled = false

--- a/patches/4B4D07E9 - Ride to Hell Retribution.patch.toml
+++ b/patches/4B4D07E9 - Ride to Hell Retribution.patch.toml
@@ -18,7 +18,6 @@ hash = "AE008C959D40A0FB" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4D5307D5 - Gears of War (TU5).patch.toml
+++ b/patches/4D5307D5 - Gears of War (TU5).patch.toml
@@ -33,49 +33,6 @@ hash = "34849A59634915F6" # default.xex
         value = 0x04
 
 [[patch]]
-    name = "Flickering Decals Fix"
-    desc = "Fixes decals (bloodpools, bullet holes, etc.) that flicker when using the Vulkan FBO or D3D12 RTV render paths."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x825acf60
-        value = 0x4bcec03c
-    [[patch.be32]]
-        address = 0x82298f9c
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x82298fa0
-        value = 0x6000d70a
-    [[patch.be32]]
-        address = 0x82298fa4
-        value = 0x90010180
-    [[patch.be32]]
-        address = 0x82298fa8
-        value = 0xc0010180
-    [[patch.be32]]
-        address = 0x82298fac
-        value = 0x48313fb8
-    [[patch.be32]]
-        address = 0x829a84d0
-        value = 0x4b8f0934
-    [[patch.be32]]
-        address = 0x82298e04
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x82298e08
-        value = 0x6000d70a
-    [[patch.be32]]
-        address = 0x82298e0c
-        value = 0x90010178
-    [[patch.be32]]
-        address = 0x82298e10
-        value = 0xc0010178
-    [[patch.be32]]
-        address = 0x82298e14
-        value = 0x4870f6c0
-
-[[patch]]
     name = "Disable Motion Blur"
     author = "illusion, boma"
     is_enabled = false

--- a/patches/4D5307D5 - Gears of War.patch.toml
+++ b/patches/4D5307D5 - Gears of War.patch.toml
@@ -27,49 +27,6 @@ hash = "1B591620508434A2" # default.xex
         value = 0x04
 
 [[patch]]
-    name = "Flickering Decals Fix"
-    desc = "Fixes decals (bloodpools, bullet holes, etc.) that flicker when using the Vulkan FBO or D3D12 RTV render paths."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82596a40 # replace DepthBias lfs, BSP receivers
-        value = 0x4bcf0984 # b 0x822873c4 code cave
-    [[patch.be32]]
-        address = 0x822873c4
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x822873c8
-        value = 0x6000d70a # 0xbc23d70a = -0.01f
-    [[patch.be32]]
-        address = 0x822873cc
-        value = 0x90010180
-    [[patch.be32]]
-        address = 0x822873d0 # Clamp DepthBias
-        value = 0xc0010180 # lfs f0, 0x180(r1)
-    [[patch.be32]]
-        address = 0x822873d4
-        value = 0x4830f670 # b 0x82596a44
-    [[patch.be32]]
-        address = 0x825c6688 # replace DepthBias lfs, static mesh receivers
-        value = 0x4bcc0ba4 # b 0x8228722c code cave
-    [[patch.be32]]
-        address = 0x8228722c
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x82287230
-        value = 0x6000d70a # 0xbc23d70a = -0.01f
-    [[patch.be32]]
-        address = 0x82287234
-        value = 0x90010178
-    [[patch.be32]]
-        address = 0x82287238 # Clamp DepthBias
-        value = 0xc0010178 # lfs f0, 0x178(r1)
-    [[patch.be32]]
-        address = 0x8228723c
-        value = 0x4833f450 # b 0x825c668c
-
-[[patch]]
     name = "Texture Streaming Fix"
     desc = "Minimizes the slow pop-in behavior common in heavy scenes, especially when using custom resolution scaling, allowing textures to stream in sooner and maintain higher visual detail during gameplay."
     author = "boma"

--- a/patches/4D5307E6 - Halo 3.patch.toml
+++ b/patches/4D5307E6 - Halo 3.patch.toml
@@ -15,7 +15,6 @@ hash = "19EB90F06A070ED6" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Removes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D5307E8 - Mass Effect.patch.toml
+++ b/patches/4D5307E8 - Mass Effect.patch.toml
@@ -34,55 +34,6 @@ hash = [ # default.xex
         value = 0x00
 
 [[patch]]
-    name = "Flickering Decals Fix"
-    desc = "Fixes decals (bloodpools, bullet holes, etc.) that flicker when using the Vulkan FBO or D3D12 RTV render paths."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x8263ca88
-        value = 0x4bf994dc
-    [[patch.be32]]
-        address = 0x825d5f68
-        value = 0x9421fff0
-    [[patch.be32]]
-        address = 0x825d5f6c
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x825d5f70
-        value = 0x6000d70a
-    [[patch.be32]]
-        address = 0x825d5f74
-        value = 0x9001000c
-    [[patch.be32]]
-        address = 0x825d5f78
-        value = 0xc001000c
-    [[patch.be32]]
-        address = 0x825d5f7c
-        value = 0x38210010
-    [[patch.be32]]
-        address = 0x825d5f80
-        value = 0x48066b0c
-    [[patch.be32]]
-        address = 0x8263cf28
-        value = 0x4bf99094
-    [[patch.be32]]
-        address = 0x825d5fbc
-        value = 0x3d80c000
-    [[patch.be32]]
-        address = 0x825d5fc0
-        value = 0x618c0000
-    [[patch.be32]]
-        address = 0x825d5fc4
-        value = 0x918101b4
-    [[patch.be32]]
-        address = 0x825d5fc8
-        value = 0xc00101b4
-    [[patch.be32]]
-        address = 0x825d5fcc
-        value = 0x48066f60
-
-[[patch]]
     name = "Skip Intro Movies"
     author = "HouseofTudor"
     is_enabled = false

--- a/patches/4D530805 - Alan Wake.patch.toml
+++ b/patches/4D530805 - Alan Wake.patch.toml
@@ -31,7 +31,6 @@ hash = "C7BBFAD65BC0D6B3" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/4D53082D - Gears of War 2 (TU6).patch.toml
+++ b/patches/4D53082D - Gears of War 2 (TU6).patch.toml
@@ -138,7 +138,6 @@ hash = "62547A005C0420D2" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D53082D - Gears of War 2.patch.toml
+++ b/patches/4D53082D - Gears of War 2.patch.toml
@@ -138,7 +138,6 @@ hash = "BDB97753374D520A" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D53085B - Halo Reach (TU1).patch.toml
+++ b/patches/4D53085B - Halo Reach (TU1).patch.toml
@@ -5,7 +5,6 @@ hash = "DBC44902DBD3BCD8" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Removes unoccluded bright lights on-screen."
     author = "boma, Sowa_95"
     is_enabled = false
 

--- a/patches/4D53085B - Halo Reach.patch.toml
+++ b/patches/4D53085B - Halo Reach.patch.toml
@@ -25,7 +25,6 @@ hash = "17887E84979FCCC7" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Removes unoccluded bright lights on-screen."
     author = "boma, Sowa_95"
     is_enabled = false
 

--- a/patches/4D5308AB - Gears of War 3 (TU6 Disc; TU1 XBL).patch.toml
+++ b/patches/4D5308AB - Gears of War 3 (TU6 Disc; TU1 XBL).patch.toml
@@ -23,8 +23,20 @@ hash = "7775898137CE1CE3" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "Occlusion Query Fix"
+    desc = "Force occlusion testing against full-resolution depth, reducing geometry popping that sometimes occurs when using strict occlusion queries."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827c4f80
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x827c9090
+        value = 0x39600000
+
+[[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "illusion, boma"
     is_enabled = false
 
@@ -34,13 +46,9 @@ hash = "7775898137CE1CE3" # default.xex
 
 [[patch]]
     name = "Disable Ambient Occlusion"
-    desc = "Fixes various artifacts when using upscaling."
     author = "illusion, boma"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x8237271c
-        value = 0x39600000
     [[patch.be32]]
         address = 0x82774444
         value = 0x39600000

--- a/patches/4D5308AB - Gears of War 3.patch.toml
+++ b/patches/4D5308AB - Gears of War 3.patch.toml
@@ -23,8 +23,20 @@ hash = "EF4AD5E9DD1982ED" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "Occlusion Query Fix"
+    desc = "Force occlusion testing against full-resolution depth, reducing geometry popping that sometimes occurs when using strict occlusion queries."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827b2bd0
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x827b6c58
+        value = 0x39600000
+
+[[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "illusion"
     is_enabled = false
 
@@ -34,13 +46,9 @@ hash = "EF4AD5E9DD1982ED" # default.xex
 
 [[patch]]
     name = "Disable Ambient Occlusion"
-    desc = "Fixes various artifacts when using upscaling."
     author = "illusion, boma"
     is_enabled = false
 
-    [[patch.be32]]
-        address = 0x82593dc4
-        value = 0x39600000
     [[patch.be32]]
         address = 0x82762c54
         value = 0x39600000

--- a/patches/4D5308C8 - Gears of War 2 (Japan).patch.toml
+++ b/patches/4D5308C8 - Gears of War 2 (Japan).patch.toml
@@ -57,7 +57,6 @@ hash = "E16F67527BD62DBD" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D530919 - Halo 4 (TU10).patch.toml
+++ b/patches/4D530919 - Halo 4 (TU10).patch.toml
@@ -8,7 +8,6 @@ hash = "465947D76056C3DA" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Removes unoccluded bright lights on-screen."
     author = "boma, Sowa_95"
     is_enabled = false
 

--- a/patches/4D530919 - Halo 4.patch.toml
+++ b/patches/4D530919 - Halo 4.patch.toml
@@ -8,7 +8,6 @@ hash = "28B1F695AC7E881F" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Removes unoccluded bright lights on-screen."
     author = "boma, Sowa_95"
     is_enabled = false
 

--- a/patches/4D530A26 - Gears of War Judgment (TU4).patch.toml
+++ b/patches/4D530A26 - Gears of War Judgment (TU4).patch.toml
@@ -26,8 +26,20 @@ hash = "013148141A27D4C7" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "Occlusion Query Fix"
+    desc = "Force occlusion testing against full-resolution depth, reducing geometry popping that sometimes occurs when using strict occlusion queries."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827de330
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x827e2540
+        value = 0x39600000
+
+[[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "illusion, boma"
     is_enabled = false
 
@@ -79,7 +91,6 @@ hash = "013148141A27D4C7" # default.xex
 
 [[patch]]
     name = "Disable Ambient Occlusion"
-    desc = "May slightly increase performance and prevent graphical arifacts when upscaling."
     author = "boma"
     is_enabled = false
 

--- a/patches/4D530A26 - Gears of War Judgment.patch.toml
+++ b/patches/4D530A26 - Gears of War Judgment.patch.toml
@@ -26,8 +26,20 @@ hash = "8429D0AE190C10DB" # default.xex
         value = 0x01
 
 [[patch]]
+    name = "Occlusion Query Fix"
+    desc = "Force occlusion testing against full-resolution depth, reducing geometry popping that sometimes occurs when using strict occlusion queries."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x827de330
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x827e2540
+        value = 0x39600000
+
+[[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "illusion"
     is_enabled = false
 
@@ -79,7 +91,6 @@ hash = "8429D0AE190C10DB" # default.xex
 
 [[patch]]
     name = "Disable Ambient Occlusion"
-    desc = "May slightly increase performance and prevent graphical arifacts when upscaling."
     author = "boma"
     is_enabled = false
 

--- a/patches/4E4D085B - Star Trek.patch.toml
+++ b/patches/4E4D085B - Star Trek.patch.toml
@@ -15,7 +15,6 @@ hash = "8CE82C4BDCED4B16" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/504307D1 - Fairytale Fights (TU1).patch.toml
+++ b/patches/504307D1 - Fairytale Fights (TU1).patch.toml
@@ -28,7 +28,6 @@ hash = "5419665E57AA444B" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/504307D1 - Fairytale Fights.patch.toml
+++ b/patches/504307D1 - Fairytale Fights.patch.toml
@@ -28,7 +28,6 @@ hash = "8748DD0E9327790A" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5345080C - Aliens Colonial Marines (TU6).patch.toml
+++ b/patches/5345080C - Aliens Colonial Marines (TU6).patch.toml
@@ -15,7 +15,6 @@ hash = "1BF22D57C72026B4" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5345080C - Aliens Colonial Marines.patch.toml
+++ b/patches/5345080C - Aliens Colonial Marines.patch.toml
@@ -15,7 +15,6 @@ hash = "54F36E4571EB4FFC" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5345082B - Planet 51 The Game.patch.toml
+++ b/patches/5345082B - Planet 51 The Game.patch.toml
@@ -28,7 +28,6 @@ hash = "D057A31F821B498A" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5345085E - Alien Isolation (TU2).patch.toml
+++ b/patches/5345085E - Alien Isolation (TU2).patch.toml
@@ -18,7 +18,6 @@ hash = "0C54A2759704615D" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     is_enabled = false
 
     [[patch.be32]]

--- a/patches/5345085E - Alien Isolation.patch.toml
+++ b/patches/5345085E - Alien Isolation.patch.toml
@@ -18,7 +18,6 @@ hash = "42B77D03F09244A3" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     is_enabled = false
 
     [[patch.be32]]

--- a/patches/5351081E - Murdered Soul Suspect (TU1).patch.toml
+++ b/patches/5351081E - Murdered Soul Suspect (TU1).patch.toml
@@ -28,7 +28,7 @@ hash = "ACAB43DD6B5B0E62" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene. Not required on occlusion_query = strict."
+    desc = "Also disables big flare in Julia encounters, changing overall look of this scene. Not required on occlusion_query = strict."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5351081E - Murdered Soul Suspect.patch.toml
+++ b/patches/5351081E - Murdered Soul Suspect.patch.toml
@@ -28,7 +28,7 @@ hash = "B2682D54AB44B0F7" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Also disables big flare in Julia encounters, changing overall look of this scene. Not required on occlusion_query = strict."
+    desc = "Also disables big flare in Julia encounters, changing overall look of this scene. Not required on occlusion_query = strict."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5451083B - 50 Cent Blood on the Sand.patch.toml
+++ b/patches/5451083B - 50 Cent Blood on the Sand.patch.toml
@@ -14,31 +14,6 @@ hash = "355BF86D7238F120" # default.xex
         value = 0x04
 
 [[patch]]
-    name = "Flickering Decals Fix"
-    desc = "Fixes decals (bloodpools, bullet holes, etc.) that flicker when using the Vulkan FBO or D3D12 RTV render paths."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x82c2987c
-        value = 0x4b9142c8
-    [[patch.be32]]
-        address = 0x8253db44
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x8253db48
-        value = 0x6000d70a
-    [[patch.be32]]
-        address = 0x8253db4c
-        value = 0x90010160
-    [[patch.be32]]
-        address = 0x8253db50
-        value = 0xc0010160
-    [[patch.be32]]
-        address = 0x8253db54
-        value = 0x486ebd2c
-
-[[patch]]
     name = "Upscaling Fix - Disable Gaussian Blur (sharper, less bloom/DoF)"
     desc = "Forces the blur radius to 0, disabling gaussian blur. Helps upscaling without having to disable all post-processing."
     author = "boma"

--- a/patches/54510846 - Homefront (TU4).patch.toml
+++ b/patches/54510846 - Homefront (TU4).patch.toml
@@ -18,7 +18,6 @@ hash = "B43F7D808FD433EF" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/54510846 - Homefront.patch.toml
+++ b/patches/54510846 - Homefront.patch.toml
@@ -18,7 +18,6 @@ hash = "D75C3C58EF304ACC" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/545407DD - The Bureau XCOM Declassified (TU1).patch.toml
+++ b/patches/545407DD - The Bureau XCOM Declassified (TU1).patch.toml
@@ -21,7 +21,6 @@ hash = "35885346223315AB" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen without breaking waypoints."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/545407DD - The Bureau XCOM Declassified.patch.toml
+++ b/patches/545407DD - The Bureau XCOM Declassified.patch.toml
@@ -21,7 +21,6 @@ hash = "C075E7B7EE3DA59E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen without breaking waypoints."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/54540843 - Spec Ops The Line (TU2).patch.toml
+++ b/patches/54540843 - Spec Ops The Line (TU2).patch.toml
@@ -34,7 +34,6 @@ hash = "AAF6F46C863E1CD8" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Probably not required on default occlusion 80/100, most (if not all) flares are hidden."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/54540843 - Spec Ops The Line.patch.toml
+++ b/patches/54540843 - Spec Ops The Line.patch.toml
@@ -34,7 +34,6 @@ hash = "982C1EC1B8C38D2E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Probably not required on default occlusion 80/100, most (if not all) flares are hidden."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5454085D - Bioshock Infinite (TU7).patch.toml
+++ b/patches/5454085D - Bioshock Infinite (TU7).patch.toml
@@ -18,7 +18,6 @@ hash = "3C7ACE1C65C88004" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/5454085D - Bioshock Infinite.patch.toml
+++ b/patches/5454085D - Bioshock Infinite.patch.toml
@@ -18,7 +18,6 @@ hash = "F965DFB1F254E4E2" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/5454087C - Borderlands 2.patch.toml
+++ b/patches/5454087C - Borderlands 2.patch.toml
@@ -17,6 +17,19 @@ hash = "7902273991112C47" # default.xex
         value = 0x01 # 0x00=unlimited; 0x01=60FPS; 0x02=30FPS
 
 [[patch]]
+    name = "Occlusion Query Fix"
+    desc = "Force occlusion testing against full-resolution depth, reducing geometry popping that sometimes occurs when using strict occlusion queries."
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x828ebfdc
+        value = 0x39600000
+    [[patch.be32]]
+        address = 0x82919180
+        value = 0x39600000
+
+[[patch]]
     name = "16x Anisotropic Filtering"
     author = "Sowa_95"
     is_enabled = false

--- a/patches/54540882 - XCOM Enemy Unknown (TU1).patch.toml
+++ b/patches/54540882 - XCOM Enemy Unknown (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "8F4A93C17ADC7606" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/54540882 - XCOM Enemy Unknown (TU2).patch.toml
+++ b/patches/54540882 - XCOM Enemy Unknown (TU2).patch.toml
@@ -18,7 +18,6 @@ hash = "BA2D0207A6921537" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/54540882 - XCOM Enemy Unknown.patch.toml
+++ b/patches/54540882 - XCOM Enemy Unknown.patch.toml
@@ -18,7 +18,6 @@ hash = "150D9A7FBC155CA9" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5454088D - The Darkness II (TU2).patch.toml
+++ b/patches/5454088D - The Darkness II (TU2).patch.toml
@@ -18,7 +18,6 @@ hash = "90A01D38E700C142" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5454088D - The Darkness II.patch.toml
+++ b/patches/5454088D - The Darkness II.patch.toml
@@ -18,7 +18,6 @@ hash = "A54DC06050AE77D4" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/545408AE - XCOM Enemy Within (TU1).patch.toml
+++ b/patches/545408AE - XCOM Enemy Within (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "6A23BE57D5715B6D" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/545408AE - XCOM Enemy Within.patch.toml
+++ b/patches/545408AE - XCOM Enemy Within.patch.toml
@@ -18,7 +18,6 @@ hash = "3B33B5481D1AB6D8" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/565707D0 - Lollipop Chainsaw (Premium Edition).patch.toml
+++ b/patches/565707D0 - Lollipop Chainsaw (Premium Edition).patch.toml
@@ -18,23 +18,12 @@ hash = "788B0C3E7B074F18" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
         address = 0x82890140
         value = 0x39400000
-
-[[patch]]
-    name = "RTV - Flickering Decals Fix"
-    desc = "Disables static decals that cause z-fighting with RTV rendering. Some visual artifacts may remain. Not necessary when using ROV."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x822ee938
-        value = 0x39600000
 
 [[patch]]
     name = "Image Quality Fix"

--- a/patches/565707D0 - Lollipop Chainsaw.patch.toml
+++ b/patches/565707D0 - Lollipop Chainsaw.patch.toml
@@ -18,56 +18,12 @@ hash = "9FEE77798A2E765C" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 
     [[patch.be32]]
         address = 0x8288f2d0
         value = 0x39400000
-
-[[patch]]
-    name = "Flickering Decals Fix"
-    desc = "Fixes decals (bloodpools, bullet holes, etc.) that flicker when using the Vulkan FBO or D3D12 RTV render paths."
-    author = "boma"
-    is_enabled = false
-
-    [[patch.be32]]
-        address = 0x826dd484
-        value = 0x4bc1bcf4
-    [[patch.be32]]
-        address = 0x822f9178
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x822f917c
-        value = 0x6000d70a
-    [[patch.be32]]
-        address = 0x822f9180
-        value = 0x90010124
-    [[patch.be32]]
-        address = 0x822f9184
-        value = 0xc0010124
-    [[patch.be32]]
-        address = 0x822f9188
-        value = 0x483e4300
-    [[patch.be32]]
-        address = 0x82596848
-        value = 0x4bd6291c
-    [[patch.be32]]
-        address = 0x822f9164
-        value = 0x3c00bc23
-    [[patch.be32]]
-        address = 0x822f9168
-        value = 0x6000d70a
-    [[patch.be32]]
-        address = 0x822f916c
-        value = 0x90010124
-    [[patch.be32]]
-        address = 0x822f9170
-        value = 0xc0010124
-    [[patch.be32]]
-        address = 0x822f9174
-        value = 0x4829d6d8
 
 [[patch]]
     name = "Disable Film Grain"

--- a/patches/57520802 - Batman Arkham City (TU6).patch.toml
+++ b/patches/57520802 - Batman Arkham City (TU6).patch.toml
@@ -28,7 +28,6 @@ hash = "DF9C269BB979E4A2" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/57520802 - Batman Arkham City GOTY.patch.toml
+++ b/patches/57520802 - Batman Arkham City GOTY.patch.toml
@@ -24,7 +24,6 @@ hash = [
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/57520802 - Batman Arkham City.patch.toml
+++ b/patches/57520802 - Batman Arkham City.patch.toml
@@ -28,7 +28,6 @@ hash = "74ED6FBB15218B9E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/57520828 - Batman Arkham Origins (TU3).patch.toml
+++ b/patches/57520828 - Batman Arkham Origins (TU3).patch.toml
@@ -37,7 +37,6 @@ hash = [
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/57520828 - Batman Arkham Origins (TU4).patch.toml
+++ b/patches/57520828 - Batman Arkham Origins (TU4).patch.toml
@@ -37,7 +37,6 @@ hash = [
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/57520828 - Batman Arkham Origins.patch.toml
+++ b/patches/57520828 - Batman Arkham Origins.patch.toml
@@ -37,7 +37,6 @@ hash = [
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "boma"
     is_enabled = false
 

--- a/patches/584109DA - Serious Sam HD TFE.patch.toml
+++ b/patches/584109DA - Serious Sam HD TFE.patch.toml
@@ -29,7 +29,6 @@ hash = "D47AE752F78BB0C1" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410A72 - Serious Sam HD TSE.patch.toml
+++ b/patches/58410A72 - Serious Sam HD TSE.patch.toml
@@ -19,7 +19,6 @@ hash = "79A46B93D0CB186F" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B22 - Alien Rage.patch.toml
+++ b/patches/58410B22 - Alien Rage.patch.toml
@@ -18,7 +18,6 @@ hash = "A820301A931819CA" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B45 - Section 8 Prejudice (TU2).patch.toml
+++ b/patches/58410B45 - Section 8 Prejudice (TU2).patch.toml
@@ -18,7 +18,6 @@ hash = "725589D4AB362E87" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B45 - Section 8 Prejudice.patch.toml
+++ b/patches/58410B45 - Section 8 Prejudice.patch.toml
@@ -18,7 +18,6 @@ hash = "C32C51664A0E3167" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B55 - Who Wants to Be a Millionaire Special Editions.patch.toml
+++ b/patches/58410B55 - Who Wants to Be a Millionaire Special Editions.patch.toml
@@ -28,7 +28,6 @@ hash = "1E27173671F6DFD4" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B6D - Dungeon Defenders (TU2).patch.toml
+++ b/patches/58410B6D - Dungeon Defenders (TU2).patch.toml
@@ -18,7 +18,6 @@ hash = "803E2C7920B0A202" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B6D - Dungeon Defenders.patch.toml
+++ b/patches/58410B6D - Dungeon Defenders.patch.toml
@@ -18,7 +18,6 @@ hash = "B3412AA5BC53A2FA" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B8D - Deadlight (TU1).patch.toml
+++ b/patches/58410B8D - Deadlight (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "A05A2F1120EAB086" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58410B8D - Deadlight.patch.toml
+++ b/patches/58410B8D - Deadlight.patch.toml
@@ -18,7 +18,6 @@ hash = "14E0D504B14AA95D" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58411233 - Alan Wake's American Nightmare.patch.toml
+++ b/patches/58411233 - Alan Wake's American Nightmare.patch.toml
@@ -24,13 +24,3 @@ hash = "EABFE0398BFFDD2E" # default.xex
     [[patch.be32]]
         address = 0x8286340c
         value = 0x60000000
-
-[[patch]]
-    name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Warning: also disables blinking flares for collectibles, making them harder to notice from a distance."
-    author = "Sowa_95"
-    is_enabled = false
-
-    [[patch.be16]]
-        address = 0x8288dcea
-        value = 0x0000

--- a/patches/5841124B - The Expendables 2 Videogame.patch.toml
+++ b/patches/5841124B - The Expendables 2 Videogame.patch.toml
@@ -50,7 +50,7 @@ hash = "19ACA563EDD0903E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Probably not required on default occlusion = 100, most (if not all) flares are hidden."
+    desc = "Probably not required on default occlusion = 100, most (if not all) flares are hidden."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58411277 - Zeno Clash 2 (TU1).patch.toml
+++ b/patches/58411277 - Zeno Clash 2 (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "2773BDBB472A895A" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58411277 - Zeno Clash 2.patch.toml
+++ b/patches/58411277 - Zeno Clash 2.patch.toml
@@ -18,7 +18,6 @@ hash = "87ED637D615A0B8E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5841127F - Serious Sam 3 BFE.patch.toml
+++ b/patches/5841127F - Serious Sam 3 BFE.patch.toml
@@ -19,7 +19,6 @@ hash = "8BC0CFFDDA0FD81E" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Probably not required on default occlusion 80/100, most (if not all) flares are hidden."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58411293 - Narco Terror.patch.toml
+++ b/patches/58411293 - Narco Terror.patch.toml
@@ -50,7 +50,7 @@ hash = "9750E833E0851857" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen. Probably not required on default occlusion = 100, most (if not all) flares are hidden."
+    desc = "Probably not required on default occlusion = 100, most (if not all) flares are hidden."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/584113C2 - Teenage Mutant Ninja Turtles Out of the Shadows.patch.toml
+++ b/patches/584113C2 - Teenage Mutant Ninja Turtles Out of the Shadows.patch.toml
@@ -15,7 +15,6 @@ hash = "165D0A96E1707894" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/584113FE - Flashback (TU1).patch.toml
+++ b/patches/584113FE - Flashback (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "F0714444D8288246" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/584113FE - Flashback.patch.toml
+++ b/patches/584113FE - Flashback.patch.toml
@@ -18,7 +18,6 @@ hash = "AD76DCA3312AEB24" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/58411403 - Marlow Briggs and the Mask of Death.patch.toml
+++ b/patches/58411403 - Marlow Briggs and the Mask of Death.patch.toml
@@ -74,7 +74,6 @@ hash = "5E23D542B161E724" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5841141A - Contrast (TU1).patch.toml
+++ b/patches/5841141A - Contrast (TU1).patch.toml
@@ -18,7 +18,6 @@ hash = "AF9D29DEE6DCAC7C" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5841141A - Contrast.patch.toml
+++ b/patches/5841141A - Contrast.patch.toml
@@ -18,7 +18,6 @@ hash = "C798A62DCA9EFE16" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5841147C - Life Is Strange (TU9).patch.toml
+++ b/patches/5841147C - Life Is Strange (TU9).patch.toml
@@ -18,7 +18,6 @@ hash = "C7F1BC64D4EBC6D6" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 

--- a/patches/5841147C - Life Is Strange.patch.toml
+++ b/patches/5841147C - Life Is Strange.patch.toml
@@ -18,7 +18,6 @@ hash = "FC21D90E7290F63C" # default.xex
 
 [[patch]]
     name = "Disable Lens Flares"
-    desc = "Fixes unoccluded bright lights on-screen."
     author = "Sowa_95"
     is_enabled = false
 


### PR DESCRIPTION
~2011-2015 UE3 games do their occlusion query testing against quarter-res depth, which Xenia struggles with. So I'm collecting patches that flip the bUseDownscaledOcclusionQueries runtime gate for all impacted games.


Cleanup:
Gears 3's `Disable Ambient Occlusion` patch actually disables both AO & Dof/UberPostProcess. Notice how the first argument in the AO patch uses one of the same offsets that `Disable Depth of Field` does... The DoF part is what makes the game more upscaling-friendly, not AO; AO isn't incompatible with scaling.

Now that scaling thresholds can circumvent most scaling woes & we have OQ support, the descriptions for all these UE3 patches probably need to be updated.

Also, all the Z-fighting decal patches have been removed. No longer essential, or even having any ostensible use-case, now that `depth_bias_shader_offset` exists.

Removed the "fixes unoccluded bright lights on-screen" that was in the description of many, many lens flares titles. These are now elective patches for anyone who doesn't want lens flares, and that's about it.