### PR TITLE
Wet & Just Cause post-process toggles

### DIFF
--- a/patches/425307DB - Wet.patch.toml
+++ b/patches/425307DB - Wet.patch.toml
@@ -20,3 +20,27 @@ hash = "9A084828F85F951B" # default.xex
     [[patch.be32]]
         address = 0x82cb09b8
         value = 0xc3e92aa0
+
+[[patch]]
+    name = "Disable Depth of Field"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x82ae6a1c
+        value = 0x39600000
+
+[[patch]]
+    name = "Disable Shaky Camera and Film Effect"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x8274f58c
+        value = 0x99430015
+    [[patch.be32]]
+        address = 0x82751514
+        value = 0x39400000
+    [[patch.be32]]
+        address = 0x82751660
+        value = 0x39400000

--- a/patches/534307D5 - Just Cause.patch.toml
+++ b/patches/534307D5 - Just Cause.patch.toml
@@ -1,0 +1,16 @@
+title_name = "Just Cause"
+title_id = "534307D5" # SC-2005
+hash = "A0E5289AF35E88F2" # default.xex
+#media_id = "6C47A625" # Disc (USA, Europe): http://redump.org/disc/14045
+
+[[patch]]
+    name = "Disable Motion Blur"
+    author = "boma"
+    is_enabled = false
+
+    [[patch.be32]]
+        address = 0x822e7a94
+        value = 0x39400000
+    [[patch.be32]]
+        address = 0x822ed158
+        value = 0x38800014


### PR DESCRIPTION
I found several never-published patches from 2022 while migrating some old S3 accounts. I gave them a quick test and they seem fine, so here ya are.